### PR TITLE
Fix Util.inspectOptions

### DIFF
--- a/src/Util.re
+++ b/src/Util.re
@@ -11,7 +11,8 @@ external makeInspectOptions:
     ~breakLength: int=?,
     ~compact: bool=?,
     ~sorted: bool=?,
-    ~getters: bool=?
+    ~getters: bool=?,
+    unit
   ) =>
   inspectOptions =
   "";


### PR DESCRIPTION
No unit means the function can't be fully applied without args