### PR TITLE
Events overhaul & various fixes

### DIFF
--- a/__tests__/Console_test.re
+++ b/__tests__/Console_test.re
@@ -1,14 +1,15 @@
 open Jest;
+let process = Process.process;
 
 describe("Console", () => {
 
   let c1 = Console.make(
     Console.consoleOptions(
-    ~stderr=Process.stderr,
+    ~stderr=Process.stderr(process),
     ~ignoreErrors=false,
     ~colorMode=true,
     ~inspectOptions=Util.inspectOptions(),
-    ~stdout=Process.stdout,
+    ~stdout=Process.stdout(process),
   ));
 
   let c2 = Console.make2({
@@ -16,7 +17,7 @@ describe("Console", () => {
     "ignoreErrors": Some(false),
     "colorMode": Some(true),
     "inspectOptions": Some(Util.inspectOptions()),
-    "stdout": Process.stdout,
+    "stdout": Process.stdout(process),
   });
 
   c1->Console.logMany([|"a", "b"|])

--- a/examples/StreamTextToFile.re
+++ b/examples/StreamTextToFile.re
@@ -1,8 +1,9 @@
 
 let data = "Sample text to write to a file!" -> Buffer.fromString;
+let process = Process.process;
 
 let outputPath = Path.relative(
-  ~from= Process.cwd(),
+  ~from= Process.cwd(process),
   ~to_="example__output.txt"
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -907,9 +907,9 @@
       }
     },
     "bs-platform": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-7.2.1.tgz",
-      "integrity": "sha512-5Opx+I/+f0nWwDmjWhE7B2xAIR4tzQKY7OPFtYO/Eprx3hnLruDPu/jAyShU+Fv8qPWnYcqulw+i0UKOE72kNA==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-7.2.2.tgz",
+      "integrity": "sha512-PWcFfN+jCTtT/rMaHDhKh+W9RUTpaRunmSF9vbLYcrJbpgCNW6aFKAY33u0P3mLxwuhshN3b4FxqGUBPj6exZQ==",
       "dev": true
     },
     "bser": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.10",
-    "bs-platform": "7.2.1"
+    "bs-platform": "7.2.2"
   }
 }

--- a/src/BigInt.re
+++ b/src/BigInt.re
@@ -6,13 +6,13 @@ type t;
 external (~-): t => t = "%negfloat";
 external (+): (t, t) => t = "%addfloat";
 external (-): (t, t) => t = "%subfloat";
-external (*): (t, t) => t = "%mulfloat";
+external ( * ): (t, t) => t = "%mulfloat";
 external (/): (t, t) => t = "%divfloat";
 external (%): (t, t) => t = "%modfloat";
-let (**): (t, t) => t = [%raw {|function (a, b) { return (a ** b); }|}];
-external (land): t => t => t = "%andint";
-external (lor): t => t => t = "%orint";
-external (lxor): t => t => t = "%xorint";
+let ( ** ): (t, t) => t = [%raw {|function (a, b) { return (a ** b); }|}];
+external (land): (t, t) => t = "%andint";
+external (lor): (t, t) => t = "%orint";
+external (lxor): (t, t) => t = "%xorint";
 let lnot: t => t = x => x lxor fromInt(-1);
-external (lsl): t => t => t = "%lslint"
-external (asr): t => t => t = "%asrint"
+external (lsl): (t, t) => t = "%lslint";
+external (asr): (t, t) => t = "%asrint";

--- a/src/BigInt.re
+++ b/src/BigInt.re
@@ -3,6 +3,8 @@ type t;
 [@bs.val] external fromInt: int => t = "BigInt";
 [@bs.val] external toInt: t => int = "Number";
 
+let%private _NEGATIVE_ONE = fromInt(-1);
+
 external (~-): t => t = "%negfloat";
 external (+): (t, t) => t = "%addfloat";
 external (-): (t, t) => t = "%subfloat";
@@ -13,6 +15,6 @@ let ( ** ): (t, t) => t = [%raw {|function (a, b) { return (a ** b); }|}];
 external (land): (t, t) => t = "%andint";
 external (lor): (t, t) => t = "%orint";
 external (lxor): (t, t) => t = "%xorint";
-let lnot: t => t = x => x lxor fromInt(-1);
+let lnot: t => t = x => x lxor _NEGATIVE_ONE;
 external (lsl): (t, t) => t = "%lslint";
 external (asr): (t, t) => t = "%asrint";

--- a/src/BigInt.re
+++ b/src/BigInt.re
@@ -1,6 +1,18 @@
 type t;
 
-[@bs.val]
-external fromInt: int => t = "BigInt";
-[@bs.val]
-external toInt: t => int = "Number";
+[@bs.val] external fromInt: int => t = "BigInt";
+[@bs.val] external toInt: t => int = "Number";
+
+external ( ~- ) : t => t = "%negfloat";
+external (+) : (t, t) => t = "%addfloat";
+external (-) : (t, t) => t = "%subfloat";
+external (*) : (t, t) => t = "%mulfloat";
+external (/) : (t, t) => t = "%divfloat";
+external (%) : (t, t) => t = "%modfloat";
+let (**): (t, t) => t = [%raw {|function (a, b) { return (a ** b); }|}];
+external (land): t => t => t = "%andint";
+external (lor): t => t => t = "%orint";
+external (lxor): t => t => t = "%xorint";
+let lnot: t => t = x => x lxor fromInt(-1);
+external (lsl) : t => t => t = "%lslint"
+external (asr) : t => t => t = "%asrint"

--- a/src/BigInt.re
+++ b/src/BigInt.re
@@ -3,16 +3,16 @@ type t;
 [@bs.val] external fromInt: int => t = "BigInt";
 [@bs.val] external toInt: t => int = "Number";
 
-external ( ~- ) : t => t = "%negfloat";
-external (+) : (t, t) => t = "%addfloat";
-external (-) : (t, t) => t = "%subfloat";
-external (*) : (t, t) => t = "%mulfloat";
-external (/) : (t, t) => t = "%divfloat";
-external (%) : (t, t) => t = "%modfloat";
+external (~-): t => t = "%negfloat";
+external (+): (t, t) => t = "%addfloat";
+external (-): (t, t) => t = "%subfloat";
+external (*): (t, t) => t = "%mulfloat";
+external (/): (t, t) => t = "%divfloat";
+external (%): (t, t) => t = "%modfloat";
 let (**): (t, t) => t = [%raw {|function (a, b) { return (a ** b); }|}];
 external (land): t => t => t = "%andint";
 external (lor): t => t => t = "%orint";
 external (lxor): t => t => t = "%xorint";
 let lnot: t => t = x => x lxor fromInt(-1);
-external (lsl) : t => t => t = "%lslint"
-external (asr) : t => t => t = "%asrint"
+external (lsl): t => t => t = "%lslint"
+external (asr): t => t => t = "%asrint"

--- a/src/ChildProcess.re
+++ b/src/ChildProcess.re
@@ -27,6 +27,8 @@ module Events = {
   [@bs.send] external emitExit: (t, [@bs.as "exit"] _, int) => bool = "emit";
   [@bs.send] external emitClose: (t, [@bs.as "close"] _, int) => bool = "emit";
 
+  [@bs.send] external removeAllListeners: t => t = "removeAllListeners";
+
 };
 include Events;
 

--- a/src/ChildProcess.re
+++ b/src/ChildProcess.re
@@ -21,6 +21,12 @@ module Events = {
   [@bs.send] external onExitOnce: (t, [@bs.as "exit"] _, (. int) => unit) => t = "once";
   [@bs.send] external onCloseOnce: (t, [@bs.as "close"] _, (. int) => unit) => t = "once";
 
+  [@bs.send] external emitData: (t, [@bs.as "data"] _, . Buffer.t) => bool = "emit"
+  [@bs.send] external emitDisconnect: (t, [@bs.as "disconnect"] _) => bool = "emit";
+  [@bs.send] external emitError: (t, [@bs.as "error"] _, Js.Exn.t) => bool = "emit";
+  [@bs.send] external emitExit: (t, [@bs.as "exit"] _, int) => bool = "emit";
+  [@bs.send] external emitClose: (t, [@bs.as "close"] _, int) => bool = "emit";
+
 };
 include Events;
 

--- a/src/ChildProcess.re
+++ b/src/ChildProcess.re
@@ -1,10 +1,28 @@
 type t;
 
-[@bs.send] external onData: (t, [@bs.as "data"] _, Buffer.t => unit) => unit = "on";
-[@bs.send] external onDisconnect: (t, [@bs.as "disconnect"] _, unit => unit) => unit = "on";
-[@bs.send] external onError: (t, [@bs.as "error"] _, Js.Exn.t => unit) => unit = "on";
-[@bs.send] external onExit: (t, [@bs.as "exit"] _, int => unit) => unit = "on";
-[@bs.send] external onClose: (t, [@bs.as "close"] _, int => unit) => unit = "on";
+
+module Events = {
+
+  [@bs.send] external onData: (t, [@bs.as "data"] _, (. Buffer.t) => unit) => t = "on";
+  [@bs.send] external onDisconnect: (t, [@bs.as "disconnect"] _, (. unit) => unit) => t = "on";
+  [@bs.send] external onError: (t, [@bs.as "error"] _, (. Js.Exn.t) => unit) => t = "on";
+  [@bs.send] external onExit: (t, [@bs.as "exit"] _, (. int) => unit) => t = "on";
+  [@bs.send] external onClose: (t, [@bs.as "close"] _, (. int) => unit) => t = "on";
+
+  [@bs.send] external offData: (t, [@bs.as "data"] _, (. Buffer.t) => unit) => t = "off"
+  [@bs.send] external offDisconnect: (t, [@bs.as "disconnect"] _, (. unit) => unit) => t = "off";
+  [@bs.send] external offError: (t, [@bs.as "error"] _, (. Js.Exn.t) => unit) => t = "off";
+  [@bs.send] external offExit: (t, [@bs.as "exit"] _, (. int) => unit) => t = "off";
+  [@bs.send] external offClose: (t, [@bs.as "close"] _, (. int) => unit) => t = "off";
+
+  [@bs.send] external onDataOnce: (t, [@bs.as "data"] _, (. Buffer.t) => unit) => t = "once"
+  [@bs.send] external onDisconnectOnce: (t, [@bs.as "disconnect"] _, (. unit) => unit) => t = "once";
+  [@bs.send] external onErrorOnce: (t, [@bs.as "error"] _, (. Js.Exn.t) => unit) => t = "once";
+  [@bs.send] external onExitOnce: (t, [@bs.as "exit"] _, (. int) => unit) => t = "once";
+  [@bs.send] external onCloseOnce: (t, [@bs.as "close"] _, (. int) => unit) => t = "once";
+
+};
+include Events;
 
 [@bs.get] external connected: t => bool = "connected";
 [@bs.send] external disconnect: t => bool = "disconnect";

--- a/src/ChildProcess.re
+++ b/src/ChildProcess.re
@@ -36,9 +36,9 @@ include Events;
 [@bs.get] external killed: t => bool = "killed";
 [@bs.get] external pid: t => int = "pid";
 [@bs.get] external ref: t => unit = "ref";
-[@bs.get] [@bs.return nullable] external stderr: t => option(Stream.t(Buffer.t, [< Net.Socket.kind | Stream.writable ])) = "stderr";
-[@bs.get] [@bs.return nullable] external stdin: t => option(Stream.t(Buffer.t, [< Net.Socket.kind | Stream.readable ])) = "stdin";
-[@bs.get] [@bs.return nullable] external stdout: t => option(Stream.t(Buffer.t, [< Net.Socket.kind | Stream.writable ])) = "stdout";
+[@bs.get] [@bs.return nullable] external stderr: t => option(Stream.Writable.subtype(Buffer.t, [< Net.Socket.kind | Stream.writable ])) = "stderr";
+[@bs.get] [@bs.return nullable] external stdin: t => option(Stream.Readable.subtype(Buffer.t, [< Net.Socket.kind | Stream.readable ])) = "stdin";
+[@bs.get] [@bs.return nullable] external stdout: t => option(Stream.Writable.subtype(Buffer.t, [< Net.Socket.kind | Stream.writable ])) = "stdout";
 [@bs.get] external unref: t => unit = "unref";
 
 type execOptions;

--- a/src/Console.re
+++ b/src/Console.re
@@ -6,8 +6,8 @@ type consoleOptions;
 [@bs.obj]
 external consoleOptions:
   (
-    ~stdout: Stream.t('data, [> Stream.writable]),
-    ~stderr: Stream.t('data, [> Stream.writable])=?,
+    ~stdout: Stream.Writable.subtype('data, 'a),
+    ~stderr: Stream.Writable.subtype('data, 'a)=?,
     ~ignoreErrors: bool=?,
     ~colorMode: bool=?,
     ~inspectOptions: Util.inspectOptions=?,
@@ -20,7 +20,7 @@ external consoleOptions:
 external make2:
   {
     ..
-    "stdout": Stream.t('data, [> Stream.writable]),
+    "stdout": Stream.Writable.subtype('data, 'a),
   } =>
   t =
   "Console";

--- a/src/Crypto.re
+++ b/src/Crypto.re
@@ -55,9 +55,9 @@ module Hash = {
   type t = subtype(Buffer.t, kind);
   module Impl = {
     include Stream.Transform.Impl;
-    [@bs.send] external copy: subtype('data, [> kind ]) => Stream.t('data, [> kind ]) = "copy"; 
-    [@bs.send] external digest: subtype('data, [> kind ]) => Buffer.t = "digest"; 
-    [@bs.send] external update: (subtype('data, [> kind ]), Buffer.t) => unit = "update";
+    [@bs.send] external copy: subtype('data, 'a) => Stream.t('data, 'a) = "copy"; 
+    [@bs.send] external digest: subtype('data, 'a) => Buffer.t = "digest"; 
+    [@bs.send] external update: (subtype('data, 'a), Buffer.t) => unit = "update";
   };
   include Impl;
 };
@@ -71,8 +71,8 @@ module Hmac = {
   type t = subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Transform.Impl;
-    [@bs.send] external digest: subtype('data, [> kind ]) => Buffer.t = "digest";
-    [@bs.send] external update: (subtype('data, [> kind ]), Buffer.t) => unit = "update";
+    [@bs.send] external digest: subtype('data, 'a) => Buffer.t = "digest";
+    [@bs.send] external update: (subtype('data, 'a), Buffer.t) => unit = "update";
   };
   include Impl;
 };
@@ -93,12 +93,12 @@ module Cipher = {
   type t = subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Transform.Impl;
-    [@bs.send] external final: (subtype('data, [> kind ]), string) => Buffer.t = "final";
-    [@bs.send] external setAAD: (subtype('data, [> kind ]), Buffer.t) => t = "setAAD";
-    [@bs.send] external setAADWith: (subtype('data, [> kind ]), Buffer.t, ~options: Stream.Transform.makeOptions) => t = "setAAD";
-    [@bs.send] external getAuthTag: subtype('data, [> kind ]) => Buffer.t = "getAuthTag";
-    [@bs.send] external setAutoPadding: (subtype('data, [> kind ]), bool) => t = "setAutoPadding";
-    [@bs.send] external update: (subtype('data, [> kind ]), Buffer.t) => Buffer.t = "update";
+    [@bs.send] external final: (subtype('data, 'a), string) => Buffer.t = "final";
+    [@bs.send] external setAAD: (subtype('data, 'a), Buffer.t) => t = "setAAD";
+    [@bs.send] external setAADWith: (subtype('data, 'a), Buffer.t, ~options: Stream.Transform.makeOptions) => t = "setAAD";
+    [@bs.send] external getAuthTag: subtype('data, 'a) => Buffer.t = "getAuthTag";
+    [@bs.send] external setAutoPadding: (subtype('data, 'a), bool) => t = "setAutoPadding";
+    [@bs.send] external update: (subtype('data, 'a), Buffer.t) => Buffer.t = "update";
   };
   include Impl;
   [@bs.module "crypto"] external make: (
@@ -120,12 +120,12 @@ module Decipher = {
   type supertype('data, 'a) = Stream.Transform.subtype('data, [< kind ] as 'a);
   type t = Stream.t(Buffer.t, [ kind ]);
   module Impl = {
-    [@bs.send] external final: (subtype('data, [> kind ]), string) => Buffer.t = "final";
-    [@bs.send] external setAAD: (subtype('data, [> kind ]), Buffer.t) => t = "setAAD";
-    [@bs.send] external setAADWith: (subtype('data, [> kind ]), Buffer.t, ~options: Stream.Transform.makeOptions) => t = "setAAD";
-    [@bs.send] external setAuthTag: (subtype('data, [> kind ]), Buffer.t) => t = "setAuthTag";
-    [@bs.send] external setAutoPatting: (subtype('data, [> kind ]), bool) => t = "setAutoPadding";
-    [@bs.send] external update: (subtype('data, [> kind ]), Buffer.t) => Buffer.t = "update";
+    [@bs.send] external final: (subtype('data, 'a), string) => Buffer.t = "final";
+    [@bs.send] external setAAD: (subtype('data, 'a), Buffer.t) => t = "setAAD";
+    [@bs.send] external setAADWith: (subtype('data, 'a), Buffer.t, ~options: Stream.Transform.makeOptions) => t = "setAAD";
+    [@bs.send] external setAuthTag: (subtype('data, 'a), Buffer.t) => t = "setAuthTag";
+    [@bs.send] external setAutoPatting: (subtype('data, 'a), bool) => t = "setAutoPadding";
+    [@bs.send] external update: (subtype('data, 'a), Buffer.t) => Buffer.t = "update";
   };
   include Impl;
   [@bs.module "crypto"] external make: (

--- a/src/Crypto.re
+++ b/src/Crypto.re
@@ -55,7 +55,7 @@ module Hash = {
   type t = subtype(Buffer.t, kind);
   module Impl = {
     include Stream.Transform.Impl;
-    [@bs.send] external copy: subtype('data, 'a) => Stream.t('data, 'a) = "copy"; 
+    [@bs.send] external copy: subtype('data, 'a) => Stream.subtype('data, 'a) = "copy"; 
     [@bs.send] external digest: subtype('data, 'a) => Buffer.t = "digest"; 
     [@bs.send] external update: (subtype('data, 'a), Buffer.t) => unit = "update";
   };
@@ -118,7 +118,7 @@ module Decipher = {
   type kind = [ Stream.transform | `Decipher ];
   type subtype('data, 'a) = Stream.Transform.subtype('data, [> kind ] as 'a);
   type supertype('data, 'a) = Stream.Transform.subtype('data, [< kind ] as 'a);
-  type t = Stream.t(Buffer.t, [ kind ]);
+  type t = subtype(Buffer.t, [ kind ]);
   module Impl = {
     [@bs.send] external final: (subtype('data, 'a), string) => Buffer.t = "final";
     [@bs.send] external setAAD: (subtype('data, 'a), Buffer.t) => t = "setAAD";

--- a/src/Crypto.re
+++ b/src/Crypto.re
@@ -11,62 +11,53 @@ module KeyObject = {
   type publicKey = [ | `PublicKey ];
   type privateKey = [ | `PrivateKey ];
   type secretKey = [ | `SecretKey ];
-
   [@bs.send] external symmetricExport: t(symmetric, [< publicKey | privateKey ]) => Buffer.t = "export";
-
   [@bs.send] external asymmetricExport: ( t(asymmetric, [< publicKey | privateKey | secretKey ])) => Buffer.t = "export";
-
   module Symmetric = {
     type kind = [ `Symmetric ];
     type nonrec t('a) = t([ kind ], 'a);
     module Impl = {
     };
   };
-
   module Asymmetric = {
     type kind = [ `Symmetric ];
     type nonrec t('a) = t([ kind ], 'a);
     module Impl = {
     };
   };
-
   module Impl = {
     include Symmetric.Impl;
     include Asymmetric.Impl;
   };
-
   include Impl;
-
 };
 
 module PivateKey = {
   include KeyObject.Impl;
   type kind = [ KeyObject.publicKey ];
   type t('a) = KeyObject.t('a, [ kind ]);
-
   [@bs.module "crypto"] external make: Buffer.t => t('a) = "createPrivateKey";
   [@bs.module "crypto"] external makeWithPassphrase: { .. "key": Buffer.t, "passphrase": Buffer.t } => t('a) = "createPrivateKey";
-
 };
 
 module PublicKey = {
   include KeyObject.Impl;
   type kind = [ KeyObject.publicKey ];
   type t('a) = KeyObject.t('a, [ kind ]);
-
   [@bs.module "crypto"] external make: Buffer.t => t('a) = "createPublicKey";
   [@bs.module "crypto"] external fromPrivateKey: KeyObject.t('a, [> KeyObject.privateKey ]) => t('a) = "createPublicKey";
-
 };
 
 module Hash = {
   type kind = [ Stream.transform | `Hash ];
-  type t = Stream.t(Buffer.t, [ kind ]); 
+  type subtype('data, 'a) = Stream.Transform.subtype(Buffer.t, [> kind ] as 'a); 
+  type supertype('data, 'a) = Stream.Transform.subtype(Buffer.t, [< kind ] as 'a); 
+  type t = subtype(Buffer.t, kind);
   module Impl = {
     include Stream.Transform.Impl;
-    [@bs.send] external copy: Stream.t('data, [> kind ]) => Stream.t('data, [> kind ]) = "copy"; 
-    [@bs.send] external digest: Stream.t('data, [> kind ]) => Buffer.t = "digest"; 
-    [@bs.send] external update: (Stream.t('data, [> kind ]), Buffer.t) => unit = "update";
+    [@bs.send] external copy: subtype('data, [> kind ]) => Stream.t('data, [> kind ]) = "copy"; 
+    [@bs.send] external digest: subtype('data, [> kind ]) => Buffer.t = "digest"; 
+    [@bs.send] external update: (subtype('data, [> kind ]), Buffer.t) => unit = "update";
   };
   include Impl;
 };
@@ -75,11 +66,13 @@ module Hash = {
 
 module Hmac = {
   type kind = [ Stream.transform | `Hmac ];
-  type t = Stream.t(Buffer.t, [ kind ]);
+  type subtype('data, 'a) = Stream.Transform.subtype('data, [> kind ] as 'a);
+  type supertype('data, 'a) = Stream.Transform.subtype('data, [< kind ] as 'a);
+  type t = subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Transform.Impl;
-    [@bs.send] external digest: Stream.t('data, [> kind ]) => Buffer.t = "digest";
-    [@bs.send] external update: (Stream.t('data, [> kind ]), Buffer.t) => unit = "update";
+    [@bs.send] external digest: subtype('data, [> kind ]) => Buffer.t = "digest";
+    [@bs.send] external update: (subtype('data, [> kind ]), Buffer.t) => unit = "update";
   };
   include Impl;
 };
@@ -87,91 +80,80 @@ module Hmac = {
 [@bs.module "crypto"] external createHmac: (string, ~key: string) => Hmac.t = "createHmac";
 
 module Certificate = {
-
   type t;
-
   [@bs.send] external exportChallenge: (t, Buffer.t) => Buffer.t = "exportChallenge"; 
-  [@bs.send] external exportPublicKey: ( t, Buffer.t) => Buffer.t = "exportPublicKey";
+  [@bs.send] external exportPublicKey: (t, Buffer.t) => Buffer.t = "exportPublicKey";
   [@bs.send] external verifyCertificate: (t, Buffer.t) => bool = "verifyCertificate"
-
 };
 
 module Cipher = {
-
   type kind = [ Stream.transform | `Cipher ];
-  type t = Stream.t(Buffer.t, [ kind ]);
-
+  type subtype('data, 'a) = Stream.Transform.subtype('data, [> kind ] as 'a);
+  type supertype('data, 'a) = Stream.Transform.subtype('data, [< kind ] as 'a);
+  type t = subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Transform.Impl;
-    [@bs.send] external final: (Stream.t('data, [> kind ]), string) => Buffer.t = "final";
-    [@bs.send] external setAAD: (Stream.t('data, [> kind ]), Buffer.t) => t = "setAAD";
-    [@bs.send] external setAADWith: (Stream.t('data, [> kind ]), Buffer.t, ~options: Stream.Transform.makeOptions) => t = "setAAD";
-    [@bs.send] external getAuthTag: Stream.t('data, [> kind ]) => Buffer.t = "getAuthTag";
-    [@bs.send] external setAutoPadding: (Stream.t('data, [> kind ]), bool) => t = "setAutoPadding";
-    [@bs.send] external update: (Stream.t('data, [> kind ]), Buffer.t) => Buffer.t = "update";
+    [@bs.send] external final: (subtype('data, [> kind ]), string) => Buffer.t = "final";
+    [@bs.send] external setAAD: (subtype('data, [> kind ]), Buffer.t) => t = "setAAD";
+    [@bs.send] external setAADWith: (subtype('data, [> kind ]), Buffer.t, ~options: Stream.Transform.makeOptions) => t = "setAAD";
+    [@bs.send] external getAuthTag: subtype('data, [> kind ]) => Buffer.t = "getAuthTag";
+    [@bs.send] external setAutoPadding: (subtype('data, [> kind ]), bool) => t = "setAutoPadding";
+    [@bs.send] external update: (subtype('data, [> kind ]), Buffer.t) => Buffer.t = "update";
   };
-
   include Impl;
-
   [@bs.module "crypto"] external make: (
       ~algorithm: string,
       ~key: KeyObject.t('a, [> KeyObject.secretKey ]),
       ~iv: Js.Null.t(Buffer.t)
     ) => t = "createCipheriv";
-
   [@bs.module "crypto"] external makeWith: (
       ~algorithm: string,
       ~key: KeyObject.t('a, [> KeyObject.secretKey ]),
       ~iv: Js.Null.t(Buffer.t),
       ~options: Stream.Transform.makeOptions=?
     ) => t = "createCipheriv";
-
 };
 
 module Decipher = {
-
   type kind = [ Stream.transform | `Decipher ];
+  type subtype('data, 'a) = Stream.Transform.subtype('data, [> kind ] as 'a);
+  type supertype('data, 'a) = Stream.Transform.subtype('data, [< kind ] as 'a);
   type t = Stream.t(Buffer.t, [ kind ]);
-
   module Impl = {
-    [@bs.send] external final: (Stream.t('data, [> kind ]), string) => Buffer.t = "final";
-    [@bs.send] external setAAD: (Stream.t('data, [> kind ]), Buffer.t) => t = "setAAD";
-    [@bs.send] external setAADWith: (Stream.t('data, [> kind ]), Buffer.t, ~options: Stream.Transform.makeOptions) => t = "setAAD";
-    [@bs.send] external setAuthTag: (Stream.t('data, [> kind ]), Buffer.t) => t = "setAuthTag";
-    [@bs.send] external setAutoPatting: (Stream.t('data, [> kind ]), bool) => t = "setAutoPadding";
-    [@bs.send] external update: (Stream.t('data, [> kind ]), Buffer.t) => Buffer.t = "update";
+    [@bs.send] external final: (subtype('data, [> kind ]), string) => Buffer.t = "final";
+    [@bs.send] external setAAD: (subtype('data, [> kind ]), Buffer.t) => t = "setAAD";
+    [@bs.send] external setAADWith: (subtype('data, [> kind ]), Buffer.t, ~options: Stream.Transform.makeOptions) => t = "setAAD";
+    [@bs.send] external setAuthTag: (subtype('data, [> kind ]), Buffer.t) => t = "setAuthTag";
+    [@bs.send] external setAutoPatting: (subtype('data, [> kind ]), bool) => t = "setAutoPadding";
+    [@bs.send] external update: (subtype('data, [> kind ]), Buffer.t) => Buffer.t = "update";
   };
-
   include Impl;
-
   [@bs.module "crypto"] external make: (
       ~algorithm: string,
       ~key: KeyObject.t('a, [> KeyObject.secretKey ]),
       ~iv: Js.Null.t(Buffer.t)
     ) => t = "createDecipheriv";
-
   [@bs.module "crypto"] external makeWith: (
       ~algorithm: string,
       ~key: KeyObject.t('a, [> KeyObject.secretKey ]),
       ~iv: Js.Null.t(Buffer.t),
       ~options: Stream.Transform.makeOptions=?
     ) => t = "createDecipheriv";
-
 };
 
-module DiffieHellman = {
+// module DiffieHellman = {
 
-};
+// };
 
-module DiffieHellmanGroup = {
+// module DiffieHellmanGroup = {
 
-};
+// };
 
-module Sign = {
+// module Sign = {
 
-};
+// };
 
-module Verify = {
+// module Verify = {
 
-};
+// };
 

--- a/src/Fs.re
+++ b/src/Fs.re
@@ -397,8 +397,8 @@ module WriteStream = {
     [@bs.send] external bytesWritten: subtype('data, [> kind ]) => int = "bytesWritten";
     [@bs.send] external path: subtype('data, [> kind ]) => string = "path";
     [@bs.send] external pending: subtype('data, [> kind ]) => bool = "pending";
-    [@bs.send] external onOpen: (subtype('data, [> kind ]), [@bs.as "open"] _, fd => unit) => unit = "on";
-    [@bs.send] external onReady: (subtype('data, [> kind ]), [@bs.as "ready"] _, unit => unit) => unit = "on";
+    [@bs.send] external onOpen: (subtype('data, [> kind ]) as 'stream', [@bs.as "open"] _, (. fd) => unit) => 'stream = "on";
+    [@bs.send] external onReady: (subtype('data, [> kind ]) as 'stream, [@bs.as "ready"] _, (. unit) => unit) => 'stream = "on";
   };
   include Impl;
 };
@@ -413,8 +413,8 @@ module ReadStream = {
     [@bs.send] external bytesRead: subtype('data, [> kind ]) => int = "bytesWritten";
     [@bs.send] external path: subtype('data, [> kind ]) => string = "path";
     [@bs.send] external pending: subtype('data, [> kind ]) => bool = "pending";
-    [@bs.send] external onOpen: (subtype('data, [> kind ]), [@bs.as "open"] _, fd => unit) => unit = "on";
-    [@bs.send] external onReady: (subtype('data, [> kind ]), [@bs.as "ready"] _, unit => unit) => unit = "on";
+    [@bs.send] external onOpen: (subtype('data, [> kind ]) as 'stream, [@bs.as "open"] _, (. fd) => unit) =>'stream = "on";
+    [@bs.send] external onReady: (subtype('data, [> kind ]) as 'stream, [@bs.as "ready"] _, (. unit) => unit) => 'stream = "on";
   };
   include Impl;
 };

--- a/src/Fs.re
+++ b/src/Fs.re
@@ -1,3 +1,26 @@
+module Dirent = {
+  type t;
+  [@bs.send] external isBlockDevice: t => bool = "isBlockDevice";
+  [@bs.send] external isCharacterDevice: t => bool = "isCharacterDevice";
+  [@bs.send] external isDirectory: t => bool = "isDirectory";
+  [@bs.send] external isFIFO: t => bool = "isFIFO";
+  [@bs.send] external isFile: t => bool = "isFile";
+  [@bs.send] external isSocket: t => bool = "isSocket";
+  [@bs.send] external isSymbolicLink: t => bool = "isSymbolicLink";
+  [@bs.get] external name: t => string = "name";
+};
+
+module Dir = {
+  type t;
+  [@bs.send] external close: t => Js.Promise.t(unit) = "close";
+  [@bs.send] external closeWithCallback: (t, Js.nullable(Js.Exn.t) => unit) => unit = "close";
+  [@bs.send] external closeSync: t => unit = "closeSync";
+  [@bs.get] external path: t => string = "path";
+  [@bs.send] external read: t => Js.Promise.t(Js.nullable(Dirent.t)) = "read";
+  [@bs.send] external readWithCallback: (t, (Js.Exn.t, Js.nullable(Dirent.t)) => unit) => unit = "read";
+  [@bs.send] external readSync: t => Js.nullable(Dirent.t) = "readSync";
+};
+
 module Stats = {
   type t = {
     [@bs.as "dev"] dev: int,
@@ -196,7 +219,6 @@ type writeFileSyncOptions;
   "";
 
 [@bs.val] [@bs.module "fs"] external writeFileSync: (string, Buffer.t) => unit = "writeFileSync";
-
 [@bs.val] [@bs.module "fs"] external writeFileSyncWith: (string, Buffer.t, writeFileSyncOptions) => unit = "writeFileSync";
 
 module Handle = {

--- a/src/Fs.re
+++ b/src/Fs.re
@@ -389,8 +389,8 @@ external openWithMode:
 
 module WriteStream = {
   type kind = [ Stream.writable | `FileSystem ];
-  type subtype('data, 'a) = Stream.Writable.subtype('data, [> kind] as 'a);
-  type supertype('data, 'a) = Stream.Writable.subtype('data, [< kind] as 'a);
+  type subtype('data, 'a) = Stream.subtype('data, [> kind] as 'a);
+  type supertype('data, 'a) = Stream.subtype('data, [< kind] as 'a);
   type t = subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Writable.Impl;
@@ -405,8 +405,8 @@ module WriteStream = {
 
 module ReadStream = {
   type kind = [ Stream.readable | `FileSystem ];
-  type subtype('data, 'a) = Stream.Readable.subtype('data, [> kind] as 'a);
-  type supertype('data, 'a) = Stream.Readable.subtype('data, [< kind] as 'a);
+  type subtype('data, 'a) = Stream.subtype('data, [> kind] as 'a);
+  type supertype('data, 'a) = Stream.subtype('data, [< kind] as 'a);
   type t = subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Readable.Impl;

--- a/src/Fs.re
+++ b/src/Fs.re
@@ -131,7 +131,7 @@ type readFileOptions;
  * Renames/moves the file located at `~oldPath` to `~newPath`. **Execution is
  * synchronous and blocking**.
  */
-[@bs.module "fs"] external renameSync: (~oldPath: string, ~newPath: string) => unit = "renameSync";
+[@bs.module "fs"] external renameSync: (~from: string, ~to_: string) => unit = "renameSync";
 [@bs.module "fs"] external ftruncateSync: (fd, int) => unit = "ftruncateSync";
 [@bs.module "fs"] external truncateSync: (string, int) => unit = "truncateSync";
 [@bs.module "fs"] external chownSync: (string, ~uid: int, ~gid: int) => unit = "chownSync";

--- a/src/Fs.re
+++ b/src/Fs.re
@@ -1,169 +1,3 @@
-type fd = pri int;
-type path = string;
-
-module Constants = {
-  [@bs.module "fs"] [@bs.val] [@bs.scope "constants"]
-  external f_ok: int = "F_OK";
-  [@bs.module "fs"] [@bs.val] [@bs.scope "constants"]
-  external w_ok: int = "W_OK";
-  [@bs.module "fs"] [@bs.val] [@bs.scope "constants"]
-  external r_ok: int = "R_OK";
-  [@bs.module "fs"] [@bs.val] [@bs.scope "constants"]
-  external x_ok: int = "X_OK";
-};
-
-[@bs.obj]
-external writeFileOption:
-  (
-    ~encoding: [@bs.string] [
-                 | `hex
-                 | `utf8
-                 | `ascii
-                 | `latin1
-                 | `base64
-                 | `ucs2
-                 | `base64
-                 | `binary
-                 | `utf16le
-               ]
-                 =?,
-    ~mode: int=?,
-    ~flag: string=?,
-    unit
-  ) =>
-  _ =
-  "";
-
-[@bs.obj]
-external mkdirOption: (~recursive: bool=?, ~mode: int=?, unit) => _ = "";
-
-type appendFileOptions;
-[@bs.obj]
-external appendFileOptions:
-  (
-    ~encoding: [@bs.string] [
-                 | `hex
-                 | `utf8
-                 | `ascii
-                 | `latin1
-                 | `base64
-                 | `ucs2
-                 | `base64
-                 | `binary
-                 | `utf16le
-               ],
-    ~mode: int=?,
-    ~flag: [@bs.string] [
-             | [@bs.as "r"] `Read
-             | [@bs.as "r+"] `ReadWrite
-             | [@bs.as "rs+"] `ReadWriteSync
-             | [@bs.as "w"] `Write
-             | [@bs.as "wx"] `WriteFailIfExists
-             | [@bs.as "w+"] `WriteRead
-             | [@bs.as "wx+"] `WriteReadFailIfExists
-             | [@bs.as "a"] `Append
-             | [@bs.as "ax"] `AppendFailIfExists
-             | [@bs.as "a+"] `AppendRead
-             | [@bs.as "ax+"] `AppendReadFailIfExists
-           ]
-             =?,
-    unit
-  ) =>
-  appendFileOptions =
-  "";
-
-type readFileOptions;
-[@bs.obj]
-external readFileOptions:
-  (
-    ~flag: [@bs.string] [
-             | [@bs.as "r"] `Read
-             | [@bs.as "r+"] `ReadWrite
-             | [@bs.as "rs+"] `ReadWriteSync
-             | [@bs.as "w"] `Write
-             | [@bs.as "wx"] `WriteFailIfExists
-             | [@bs.as "w+"] `WriteRead
-             | [@bs.as "wx+"] `WriteReadFailIfExists
-             | [@bs.as "a"] `Append
-             | [@bs.as "ax"] `AppendFailIfExists
-             | [@bs.as "a+"] `AppendRead
-             | [@bs.as "ax+"] `AppendReadFailIfExists
-           ]
-             =?,
-    unit
-  ) =>
-  readFileOptions =
-  "";
-
-type readFileStringOptions;
-[@bs.obj]
-external readFileStringOptions:
-  (
-    ~encoding: [@bs.string] [
-                 | `hex
-                 | `utf8
-                 | `ascii
-                 | `latin1
-                 | `base64
-                 | `ucs2
-                 | `base64
-                 | `binary
-                 | `utf16le
-               ],
-    ~flag: [@bs.string] [
-             | [@bs.as "r"] `Read
-             | [@bs.as "r+"] `ReadWrite
-             | [@bs.as "rs+"] `ReadWriteSync
-             | [@bs.as "w"] `Write
-             | [@bs.as "wx"] `WriteFailIfExists
-             | [@bs.as "w+"] `WriteRead
-             | [@bs.as "wx+"] `WriteReadFailIfExists
-             | [@bs.as "a"] `Append
-             | [@bs.as "ax"] `AppendFailIfExists
-             | [@bs.as "a+"] `AppendRead
-             | [@bs.as "ax+"] `AppendReadFailIfExists
-           ]
-             =?,
-    unit
-  ) =>
-  readFileStringOptions =
-  "";
-
-type writeFileUint8ArrayOptions;
-[@bs.obj]
-external writeFileUint8ArrayOptions:
-  (
-    ~encoding: [@bs.string] [
-                 | `hex
-                 | `utf8
-                 | `ascii
-                 | `latin1
-                 | `base64
-                 | `ucs2
-                 | `base64
-                 | `binary
-                 | `utf16le
-               ],
-    ~mode: int=?,
-    ~flag: [@bs.string] [
-             | [@bs.as "r"] `Read
-             | [@bs.as "r+"] `ReadWrite
-             | [@bs.as "rs+"] `ReadWriteSync
-             | [@bs.as "w"] `Write
-             | [@bs.as "wx"] `WriteFailIfExists
-             | [@bs.as "w+"] `WriteRead
-             | [@bs.as "wx+"] `WriteReadFailIfExists
-             | [@bs.as "a"] `Append
-             | [@bs.as "ax"] `AppendFailIfExists
-             | [@bs.as "a+"] `AppendRead
-             | [@bs.as "ax+"] `AppendReadFailIfExists
-           ]
-             =?,
-    unit
-  ) =>
-  writeFileUint8ArrayOptions =
-  "";
-
 module Stats = {
   type t = {
     [@bs.as "dev"] dev: int,
@@ -201,6 +35,67 @@ module Stats = {
   /** `isBlockDevice(stats)` Returns true if the `stats` object describes a socket. */
   [@bs.send] external isSocket: t => bool = "isSocket";
 };
+
+module Constants = {
+  [@bs.module "fs"] [@bs.val] [@bs.scope "constants"]
+  external f_ok: int = "F_OK";
+  [@bs.module "fs"] [@bs.val] [@bs.scope "constants"]
+  external w_ok: int = "W_OK";
+  [@bs.module "fs"] [@bs.val] [@bs.scope "constants"]
+  external r_ok: int = "R_OK";
+  [@bs.module "fs"] [@bs.val] [@bs.scope "constants"]
+  external x_ok: int = "X_OK";
+};
+
+type fd = pri int;
+type path = string;
+
+type writeFileOptions;
+[@bs.obj] external writeFileOptions: (~mode: int=?, ~flag: string=?, unit) => writeFileOptions = "";
+
+type appendFileOptions;
+[@bs.obj] external appendFileOptions: (
+    ~mode: int=?,
+    ~flag: [@bs.string] [
+             | [@bs.as "r"] `Read
+             | [@bs.as "r+"] `ReadWrite
+             | [@bs.as "rs+"] `ReadWriteSync
+             | [@bs.as "w"] `Write
+             | [@bs.as "wx"] `WriteFailIfExists
+             | [@bs.as "w+"] `WriteRead
+             | [@bs.as "wx+"] `WriteReadFailIfExists
+             | [@bs.as "a"] `Append
+             | [@bs.as "ax"] `AppendFailIfExists
+             | [@bs.as "a+"] `AppendRead
+             | [@bs.as "ax+"] `AppendReadFailIfExists
+           ]
+             =?,
+    unit
+  ) =>
+  appendFileOptions =
+  "";
+
+type readFileOptions;
+[@bs.obj] external readFileOptions:
+  (
+    ~flag: [@bs.string] [
+             | [@bs.as "r"] `Read
+             | [@bs.as "r+"] `ReadWrite
+             | [@bs.as "rs+"] `ReadWriteSync
+             | [@bs.as "w"] `Write
+             | [@bs.as "wx"] `WriteFailIfExists
+             | [@bs.as "w+"] `WriteRead
+             | [@bs.as "wx+"] `WriteReadFailIfExists
+             | [@bs.as "a"] `Append
+             | [@bs.as "ax"] `AppendFailIfExists
+             | [@bs.as "a+"] `AppendRead
+             | [@bs.as "ax+"] `AppendReadFailIfExists
+           ]
+             =?,
+    unit
+  ) =>
+  readFileOptions =
+  "";
 
 /**
  * `readdirSync(path)`
@@ -247,7 +142,7 @@ external openSync:
       | [@bs.as "ax+"] `AppendReadFailIfExists
     ]
   ) =>
-  unit =
+  fd =
   "openSync";
 
 [@bs.module "fs"] [@bs.val]
@@ -273,44 +168,13 @@ external openSyncMode:
   fd =
   "openSync";
 
-[@bs.val] [@bs.module "fs"] external readFileSync: string => string = "readFileSync";
+[@bs.val] [@bs.module "fs"] external readFileSync: (string) => Buffer.t = "readFileSync";
+[@bs.val] [@bs.module "fs"] external readFileSyncWith: (string, readFileOptions) => Buffer.t = "readFileSync";
+[@bs.val] [@bs.module "fs"] external existsSync: (string) => bool = "existsSync";
 
-[@bs.val] [@bs.module "fs"]
-external readFileSyncWithEncoding:
-  (
-    string,
-    [@bs.string] [
-      | `hex
-      | `utf8
-      | `ascii
-      | `latin1
-      | `base64
-      | `ucs2
-      | `base64
-      | `binary
-      | `utf16le
-    ]
-  ) =>
-  string =
-  "readFileSync";
-
-[@bs.val] [@bs.module "fs"] external existsSync: string => bool = "existsSync";
-
-/** create options for the `writeFileSyncOptions` */
 type writeFileSyncOptions;
 [@bs.obj] external writeFileSyncOptions:
   (
-    ~encoding: [@bs.string] [
-                 | `hex
-                 | `utf8
-                 | `ascii
-                 | `latin1
-                 | `base64
-                 | `ucs2
-                 | `base64
-                 | `binary
-                 | `utf16le
-               ],
     ~mode: int=?,
     ~flag: [@bs.string] [
              | [@bs.as "r"] `Read
@@ -355,88 +219,20 @@ module Handle = {
   [@bs.send] external readFile: t => Js.Promise.t(Buffer.t) = "read";
   [@bs.send] external readFileWith: (t, readFileOptions) => Js.Promise.t(Buffer.t) = "read";
 
-  type readFileStringOptions;
-  [@bs.obj] external readFileStringOptions:
-    (
-      ~encoding: [@bs.string] [
-                   | `hex
-                   | `utf8
-                   | `ascii
-                   | `latin1
-                   | `base64
-                   | `ucs2
-                   | `base64
-                   | `binary
-                   | `utf16le
-                 ],
-      ~flag: [@bs.string] [
-               | [@bs.as "r"] `Read
-               | [@bs.as "r+"] `ReadWrite
-               | [@bs.as "rs+"] `ReadWriteSync
-               | [@bs.as "w"] `Write
-               | [@bs.as "wx"] `WriteFailIfExists
-               | [@bs.as "w+"] `WriteRead
-               | [@bs.as "wx+"] `WriteReadFailIfExists
-               | [@bs.as "a"] `Append
-               | [@bs.as "ax"] `AppendFailIfExists
-               | [@bs.as "a+"] `AppendRead
-               | [@bs.as "ax+"] `AppendReadFailIfExists
-             ]
-               =?,
-      unit
-    ) =>
-    readFileStringOptions =
-    "";
-
-  [@bs.send] external readFileString: (t, readFileStringOptions) => Js.Promise.t(string) = "read";
   [@bs.send] external stat: t => Js.Promise.t(Stats.t) = "stat";
   [@bs.send] external sync: t => Js.Promise.t(unit) = "sync";
   [@bs.send] external truncate: (t, ~length: int=?, unit) => Js.Promise.t(unit) = "truncate";
 
   type writeInfo = {bytesWritten: int};
 
-  [@bs.send] external writeBuffer: (t, Buffer.t) => Js.Promise.t(writeInfo) = "write";
-  [@bs.send] external writeBufferOffset: (t, Buffer.t, ~offset: int) => Js.Promise.t(writeInfo) = "write";
-  [@bs.send] external writeBufferRange: (t, Buffer.t, ~offset: int, ~length: int, ~position: int) => Js.Promise.t(writeInfo) = "write";
+  [@bs.send] external write: (t, Buffer.t) => Js.Promise.t(writeInfo) = "write";
+  [@bs.send] external writeOffset: (t, Buffer.t, ~offset: int) => Js.Promise.t(writeInfo) = "write";
+  [@bs.send] external writeRange: (t, Buffer.t, ~offset: int, ~length: int, ~position: int) => Js.Promise.t(writeInfo) = "write";
 
-  [@bs.send] external writeString: (t, string) => Js.Promise.t(writeInfo) = "write";
-  [@bs.send] external writeStringOffset: (t, string, ~offset: int) => Js.Promise.t(writeInfo) = "write";
-  [@bs.send] external writeStringRange: (t, string, ~offset: int, ~length: int, ~position: int) => Js.Promise.t(writeInfo) = "write";
-  [@bs.send] external writeStringPosition: (t, string, ~position: int) => Js.Promise.t(writeInfo) = "write";
-  [@bs.send] external writeStringPositionWithEncoding:
-    (
-      t,
-      string,
-      ~position: int,
-      ~encoding: [@bs.string] [
-                   | `hex
-                   | `utf8
-                   | `ascii
-                   | `latin1
-                   | `base64
-                   | `ucs2
-                   | `base64
-                   | `binary
-                   | `utf16le
-                 ]
-    ) =>
-    Js.Promise.t(writeInfo) =
-    "write";
 
-  type writeFileStringOptions;
-  [@bs.obj] external writeFileStringOptions:
+  type writeFileOptions;
+  [@bs.obj] external writeFileOptions:
     (
-      ~encoding: [@bs.string] [
-                   | `hex
-                   | `utf8
-                   | `ascii
-                   | `latin1
-                   | `base64
-                   | `ucs2
-                   | `base64
-                   | `binary
-                   | `utf16le
-                 ],
       ~mode: int=?,
       ~flag: [@bs.string] [
                | [@bs.as "r"] `Read
@@ -454,56 +250,12 @@ module Handle = {
                =?,
       unit
     ) =>
-    writeFileStringOptions =
+    writeFileOptions =
     "";
 
-  [@bs.send] external writeFileString: (t, string) => Js.Promise.t(unit) = "writeFile";
-  [@bs.send] external writeFileStringWith: (t, string, writeFileStringOptions) => Js.Promise.t(unit) = "writeFile";
+  [@bs.send] external writeFile: (t, Buffer.t) => Js.Promise.t(unit) = "writeFile";
+  [@bs.send] external writeFileWith: (t, Buffer.t, writeFileOptions) => Js.Promise.t(unit) = "writeFile";
 
-  type writeFileBufferOptions;
-  [@bs.obj] external writeFileBufferOptions:
-    (
-      ~encoding: [@bs.string] [
-                   | `hex
-                   | `utf8
-                   | `ascii
-                   | `latin1
-                   | `base64
-                   | `ucs2
-                   | `base64
-                   | `binary
-                   | `utf16le
-                 ],
-      ~mode: int=?,
-      ~flag: [@bs.string] [
-               | [@bs.as "r"] `Read
-               | [@bs.as "r+"] `ReadWrite
-               | [@bs.as "rs+"] `ReadWriteSync
-               | [@bs.as "w"] `Write
-               | [@bs.as "wx"] `WriteFailIfExists
-               | [@bs.as "w+"] `WriteRead
-               | [@bs.as "wx+"] `WriteReadFailIfExists
-               | [@bs.as "a"] `Append
-               | [@bs.as "ax"] `AppendFailIfExists
-               | [@bs.as "a+"] `AppendRead
-               | [@bs.as "ax+"] `AppendReadFailIfExists
-             ]
-               =?,
-      unit
-    ) =>
-    writeFileBufferOptions =
-    "";
-
-  [@bs.send] external writeFileBuffer: (t, Buffer.t) => Js.Promise.t(unit) = "writeFile";
-
-  [@bs.send] external writeFileBufferWith: (t, Buffer.t, writeFileBufferOptions) => Js.Promise.t(unit) = "writeFile";
-
-  [@bs.send] external writeFileUint8Array: (t, Js.TypedArray2.Uint8Array.t) => Js.Promise.t(unit) = "writeFile";
-
-  [@bs.send] external writeFileUint8ArrayWith:
-    (t, Js.TypedArray2.Uint8Array.t, writeFileUint8ArrayOptions) =>
-    Js.Promise.t(unit) =
-    "writeFile";
 };
 
 [@bs.module "fs"] [@bs.scope "promises"] external access: string => Js.Promise.t(unit) = "access";
@@ -519,17 +271,6 @@ module Handle = {
 type appendFileBufferOptions;
 [@bs.obj] external appendFileBufferOptions:
   (
-    ~encoding: [@bs.string] [
-                 | `hex
-                 | `utf8
-                 | `ascii
-                 | `latin1
-                 | `base64
-                 | `ucs2
-                 | `base64
-                 | `binary
-                 | `utf16le
-               ],
     ~mode: int=?,
     ~flag: [@bs.string] [
              | [@bs.as "r"] `Read
@@ -589,8 +330,7 @@ external lstatBigInt: (string, bool) => Js.Promise.t(Stats.t) = "lstat";
 
 type mkdirOptions;
 [@bs.obj]
-external mkdirOptions: (~recursive: bool=?, ~mode: int=?, unit) => mkdirOptions =
-  "";
+external mkdirOptions: (~recursive: bool=?, ~mode: int=?, unit) => mkdirOptions = "";
 
 [@bs.module "fs"] [@bs.scope "promises"]
 external mkdir: (string, mkdirOptions) => Js.Promise.t(unit) = "mkdir";
@@ -600,23 +340,7 @@ external mkdirWith: (string, mkdirOptions) => Js.Promise.t(unit) = "mkdir";
 
 type mdktempOptions;
 [@bs.obj]
-external mdktempOptions:
-  (
-    ~encoding: [@bs.string] [
-                 | `hex
-                 | `utf8
-                 | `ascii
-                 | `latin1
-                 | `base64
-                 | `ucs2
-                 | `base64
-                 | `binary
-                 | `utf16le
-               ],
-    unit
-  ) =>
-  mdktempOptions =
-  "";
+external mdktempOptions: (unit) => mdktempOptions = "";
 
 [@bs.module "fs"] [@bs.scope "promises"]
 external mkdtemp: (string, mdktempOptions) => Js.Promise.t(unit) = "mkddtemp";
@@ -670,28 +394,32 @@ external openWithMode:
 
 module WriteStream = {
   type kind = [ Stream.writable | `FileSystem ];
-  type t = Stream.t(Buffer.t, [ kind ]);
+  type subtype('data, 'a) = Stream.Writable.subtype('data, [> kind] as 'a);
+  type supertype('data, 'a) = Stream.Writable.subtype('data, [< kind] as 'a);
+  type t = subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Writable.Impl;
-    [@bs.send] external bytesWritten: Stream.t('data, [> kind ]) => int = "bytesWritten";
-    [@bs.send] external path: Stream.t('data, [> kind ]) => string = "path";
-    [@bs.send] external pending: Stream.t('data, [> kind ]) => bool = "pending";
-    [@bs.send] external onOpen: (Stream.t('data, [> kind ]), [@bs.as "open"] _, fd => unit) => unit = "on";
-    [@bs.send] external onReady: (Stream.t('data, [> kind ]), [@bs.as "ready"] _, unit => unit) => unit = "on";
+    [@bs.send] external bytesWritten: subtype('data, [> kind ]) => int = "bytesWritten";
+    [@bs.send] external path: subtype('data, [> kind ]) => string = "path";
+    [@bs.send] external pending: subtype('data, [> kind ]) => bool = "pending";
+    [@bs.send] external onOpen: (subtype('data, [> kind ]), [@bs.as "open"] _, fd => unit) => unit = "on";
+    [@bs.send] external onReady: (subtype('data, [> kind ]), [@bs.as "ready"] _, unit => unit) => unit = "on";
   };
   include Impl;
 };
 
 module ReadStream = {
   type kind = [ Stream.readable | `FileSystem ];
-  type t = Stream.t(Buffer.t, [ kind ]);
+  type subtype('data, 'a) = Stream.Readable.subtype('data, [> kind] as 'a);
+  type supertype('data, 'a) = Stream.Readable.subtype('data, [< kind] as 'a);
+  type t = subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Readable.Impl;
-    [@bs.send] external bytesRead: Stream.t('data, [> kind ]) => int = "bytesWritten";
-    [@bs.send] external path: Stream.t('data, [> kind ]) => string = "path";
-    [@bs.send] external pending: Stream.t('data, [> kind ]) => bool = "pending";
-    [@bs.send] external onOpen: (Stream.t('data, [> kind ]), [@bs.as "open"] _, fd => unit) => unit = "on";
-    [@bs.send] external onReady: (Stream.t('data, [> kind ]), [@bs.as "ready"] _, unit => unit) => unit = "on";
+    [@bs.send] external bytesRead: subtype('data, [> kind ]) => int = "bytesWritten";
+    [@bs.send] external path: subtype('data, [> kind ]) => string = "path";
+    [@bs.send] external pending: subtype('data, [> kind ]) => bool = "pending";
+    [@bs.send] external onOpen: (subtype('data, [> kind ]), [@bs.as "open"] _, fd => unit) => unit = "on";
+    [@bs.send] external onReady: (subtype('data, [> kind ]), [@bs.as "ready"] _, unit => unit) => unit = "on";
   };
   include Impl;
 };
@@ -701,7 +429,6 @@ type createReadStreamOptions;
 external createReadStreamOptions:
   (
     ~flags: string=?,
-    ~encoding: string=?,
     ~fd: fd=?,
     ~mode: int=?,
     ~autoClose: bool=?,
@@ -725,7 +452,6 @@ type createWriteStreamOptions;
 external createWriteStreamOptions:
   (
     ~flags: string=?,
-    ~encoding: string=?,
     ~fd: fd=?,
     ~mode: int=?,
     ~autoClose: bool=?,

--- a/src/Fs.re
+++ b/src/Fs.re
@@ -71,7 +71,6 @@ module Constants = {
 };
 
 type fd = pri int;
-type path = string;
 
 type writeFileOptions;
 [@bs.obj] external writeFileOptions: (~mode: int=?, ~flag: string=?, unit) => writeFileOptions = "";
@@ -147,11 +146,10 @@ type readFileOptions;
  */
 [@bs.module "fs"] external rmdirSync: string => unit = "rmdirSync";
 
-[@bs.module "fs"]
-external openSync:
-  (
-    path,
-    [@bs.string] [
+[@bs.module "fs"] external openSync: string => fd = "openSync";
+[@bs.module "fs"] external openSyncWith: (
+    string,
+    ~flag: [@bs.string] [
       | [@bs.as "r"] `Read
       | [@bs.as "r+"] `ReadWrite
       | [@bs.as "rs+"] `ReadWriteSync
@@ -163,37 +161,12 @@ external openSync:
       | [@bs.as "ax"] `AppendFailIfExists
       | [@bs.as "a+"] `AppendRead
       | [@bs.as "ax+"] `AppendReadFailIfExists
-    ]
-  ) =>
-  fd =
-  "openSync";
+    ]=?,
+    ~mode: int=?
+  ) => fd = "openSync";
 
-[@bs.module "fs"] [@bs.val]
-external openSyncMode:
-  (
-    path,
-    [@bs.string] [
-      | [@bs.as "r"] `Read
-      | [@bs.as "r+"] `ReadWrite
-      | [@bs.as "rs+"] `ReadWriteSync
-      | [@bs.as "w"] `Write
-      | [@bs.as "wx"] `WriteFailIfExists
-      | [@bs.as "w+"] `WriteRead
-      | [@bs.as "wx+"] `WriteReadFailIfExists
-      | [@bs.as "a"] `Append
-      | [@bs.as "ax"] `AppendFailIfExists
-      | [@bs.as "a+"] `AppendRead
-      | [@bs.as "ax+"] `AppendReadFailIfExists
-    ],
-    ~mode: int,
-    unit
-  ) =>
-  fd =
-  "openSync";
-
-[@bs.val] [@bs.module "fs"] external readFileSync: (string) => Buffer.t = "readFileSync";
-[@bs.val] [@bs.module "fs"] external readFileSyncWith: (string, readFileOptions) => Buffer.t = "readFileSync";
-[@bs.val] [@bs.module "fs"] external existsSync: (string) => bool = "existsSync";
+[@bs.module "fs"] external readFileSync: (string, ~options: readFileOptions=?, unit) => Buffer.t = "readFileSync";
+[@bs.module "fs"] external existsSync: (string) => bool = "existsSync";
 
 type writeFileSyncOptions;
 [@bs.obj] external writeFileSyncOptions:
@@ -374,7 +347,7 @@ external mkdtempWith: (string, mdktempOptions) => Js.Promise.t(unit) =
 [@bs.module "fs"] [@bs.scope "promises"]
 external open_:
   (
-    path,
+    string,
     [@bs.string] [
       | [@bs.as "r"] `Read
       | [@bs.as "r+"] `ReadWrite
@@ -395,7 +368,7 @@ external open_:
 [@bs.module "fs"] [@bs.scope "promises"]
 external openWithMode:
   (
-    path,
+    string,
     [@bs.string] [
       | [@bs.as "r"] `Read
       | [@bs.as "r+"] `ReadWrite
@@ -464,9 +437,9 @@ external createReadStreamOptions:
   "";
 
 [@bs.module "fs"]
-external createReadStream: path => ReadStream.t = "createReadStream";
+external createReadStream: string => ReadStream.t = "createReadStream";
 [@bs.module "fs"]
-external createReadStreamWith: (path, createReadStreamOptions) => ReadStream.t =
+external createReadStreamWith: (string, createReadStreamOptions) => ReadStream.t =
   "createReadStream";
 
 type createWriteStreamOptions;
@@ -485,7 +458,7 @@ external createWriteStreamOptions:
   createReadStreamOptions =
   "";
 [@bs.module "fs"]
-external createWriteStream: path => WriteStream.t = "createWriteStream";
+external createWriteStream: string => WriteStream.t = "createWriteStream";
 
 [@bs.module "fs"]
-external createWriteStreamWith: (path, createWriteStreamOptions) => WriteStream.t = "createWriteStream";
+external createWriteStreamWith: (string, createWriteStreamOptions) => WriteStream.t = "createWriteStream";

--- a/src/Http.re
+++ b/src/Http.re
@@ -1,41 +1,40 @@
 type http = [ `Http ];
 
 module IncomingMessage = {
-
   type kind = [ Stream.readable | `IncomingMessage ];
-  type t = Stream.t(Buffer.t, [ kind ]);
-
+  type subtype('data, 'a) = Stream.subtype('data, [> kind] as 'a);
+  type supertype('data, 'a) = Stream.subtype('data, [< kind] as 'a);
+  type t = subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Readable.Impl;
-    [@bs.get] external method_: Stream.t('data, [> kind ]) => string = "method";
-    [@bs.get] external url: Stream.t('data, [> kind ]) => string = "url";
-    [@bs.get] external port: Stream.t('data, [> kind ]) => int = "port";
-    [@bs.get] external headers: Stream.t('data, [> kind ]) => Js.Dict.t(string) = "headers";
-    [@bs.get] external rawHeaders: Stream.t('data, [> kind ]) => array(string) = "rawHeaders";
-    [@bs.get] external rawTrailers: Stream.t('data, [> kind ]) => array(string) = "rawTrailers";
-    [@bs.get] external connection: Stream.t('data, [> kind ]) => Net.TcpSocket.t = "connection";
-    [@bs.get] external aborted: Stream.t('data, [> kind ]) => bool = "aborted";
-    [@bs.get] external complete: Stream.t('data, [> kind ]) => bool = "complete";
-    [@bs.send] external destroy: Stream.t('data, [> kind ]) => unit = "destroy";
-    [@bs.send] external destroyWithError: (Stream.t('data, [> kind ]), Js.Exn.t) => bool = "destroy";
-    [@bs.send] external setTimeout: (Stream.t('data, [> kind ] as 'a), int) => Stream.t('data, [> kind ] as 'a) = "setTimeout";
-    [@bs.send] external setTimeoutWithCallback: (Stream.t('data, [> kind ] as 'a), int, Stream.t('data, [> kind ] as 'a) => unit) => Stream.t('data, [> kind ] as 'a) = "setTimeout";
-    [@bs.get] external socket: Stream.t('data, [> kind ]) => Stream.Duplex.t('data) = "socket";
-    [@bs.get] external statusCode: Stream.t('data, [> kind ]) => int = "statusCode";
-    [@bs.get] external statusMessage: Stream.t('data, [> kind ]) => string = "statusMessage";
-    [@bs.get] external trailers: Stream.t('data, [> kind ]) => Js.Dict.t(string) = "trailers";
+    [@bs.get] external method_: subtype('data, 'a) => string = "method";
+    [@bs.get] external url: subtype('data, 'a) => string = "url";
+    [@bs.get] external port: subtype('data, 'a) => int = "port";
+    [@bs.get] external headers: subtype('data, 'a) => Js.Dict.t(string) = "headers";
+    [@bs.get] external rawHeaders: subtype('data, 'a) => array(string) = "rawHeaders";
+    [@bs.get] external rawTrailers: subtype('data, 'a) => array(string) = "rawTrailers";
+    [@bs.get] external connection: subtype('data, 'a) => Net.TcpSocket.t = "connection";
+    [@bs.get] external aborted: subtype('data, 'a) => bool = "aborted";
+    [@bs.get] external complete: subtype('data, 'a) => bool = "complete";
+    [@bs.send] external destroy: subtype('data, 'a) => unit = "destroy";
+    [@bs.send] external destroyWithError: (subtype('data, 'a), Js.Exn.t) => bool = "destroy";
+    [@bs.send] external setTimeout: (subtype('data, 'a), int) => subtype('data, 'a) = "setTimeout";
+    [@bs.send] external setTimeoutWithCallback: (subtype('data, 'a), int, subtype('data, 'a) => unit) => subtype('data, 'a) = "setTimeout";
+    [@bs.get] external socket: subtype('data, 'a) => Net.Socket.subtype('b) = "socket";
+    [@bs.get] external statusCode: subtype('data, 'a) => int = "statusCode";
+    [@bs.get] external statusMessage: subtype('data, 'a) => string = "statusMessage";
+    [@bs.get] external trailers: subtype('data, 'a) => Js.Dict.t(string) = "trailers";
   };
   include Impl;
 };
 
 module ClientRequest = {
-
   type kind = [ Stream.duplex | `ClientRequest ];
-  type nonrec t = Stream.t(Buffer.t, [ kind ]);
-
+  type subtype('data, 'a) = Stream.subtype('data, [> kind] as 'a);
+  type supertype('data, 'a) = Stream.subtype('data, [< kind] as 'a);
+  type t = subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Duplex.Impl;
-
     type information('a) = {
       .
       "httpVersion": string,
@@ -46,47 +45,46 @@ module ClientRequest = {
       "headers": Js.t({..} as 'a),
       "rawHeaders": array(string),
     };
-
-    [@bs.send] external onAbort: (Stream.t('data, [> kind]), [@bs.as "abort"] _, unit => unit) => unit = "on";
+    [@bs.send] external onAbort: (subtype('data, 'a), [@bs.as "abort"] _, unit => unit) => unit = "on";
     [@bs.send] external onConnect: (
-        Stream.t('data, [> kind]),
+        subtype('data, 'a),
         [@bs.as "connect"] _,
         (
-          Stream.t('data, [> IncomingMessage.kind ]),
-          Stream.t('data, [> Net.Socket.kind ]),
+          IncomingMessage.subtype('data, 'b),
+          Net.Socket.subtype('c),
           Buffer.t
         ) => unit
       ) => unit = "on";
-    [@bs.send] external onContinue: (Stream.t('data, [> kind ]), [@bs.as "continue"] _, unit => unit) => unit = "on";
-    [@bs.send] external onInformation: (Stream.t('data, [> kind ]), [@bs.as "information"] _, information('a) => unit) => unit = "on";
-    [@bs.send] external onResponse: (Stream.t('data, [> kind ]), [@bs.as "response"] _, Stream.t('data, [> IncomingMessage.kind ]) => unit) => unit = "on";
-    [@bs.send] external onSocket: (Stream.t('data, [> kind ]), [@bs.as "socket"] _, Stream.t('data, [> Net.Socket.kind ]) => unit) => unit = "on";
-    [@bs.send] external onTimeout: (Stream.t('data, [> kind ]), [@bs.as "timeout"] _, unit => unit) => unit = "on";
+    [@bs.send] external onContinue: (subtype('data, 'a), [@bs.as "continue"] _, unit => unit) => unit = "on";
+    [@bs.send] external onInformation: (subtype('data, 'a), [@bs.as "information"] _, information('b) => unit) => unit = "on";
+    [@bs.send] external onResponse: (subtype('data, 'a), [@bs.as "response"] _, IncomingMessage.subtype('data, 'b) => unit) => unit = "on";
+    [@bs.send] external onSocket: (subtype('data, 'a), [@bs.as "socket"] _, Net.TcpSocket.t => unit) => unit = "on";
+    [@bs.send] external onTimeout: (subtype('data, 'a), [@bs.as "timeout"] _, unit => unit) => unit = "on";
     [@bs.send] external onUpgrade:
-      (Stream.t('data, [> kind ]), [@bs.as "upgrade"] _, (Stream.t('data, [> IncomingMessage.kind ]), Stream.t('data, [> Net.Socket.kind ]), Buffer.t) => unit) => unit =
+      (subtype('data, 'a), [@bs.as "upgrade"] _, (IncomingMessage.subtype('data, 'b), Net.TcpSocket.t, Buffer.t) => unit) => unit =
       "on";
-    [@bs.send] external abort: Stream.t('data, [> kind ]) => unit = "abort";
-    [@bs.get] external aborted: Stream.t('data, [> kind ]) => bool = "aborted";
-    [@bs.send] external end_: Stream.t('data, [> kind ]) => unit = "end";
-    [@bs.send] external endWithData: (Stream.t('data, [> kind ]), Buffer.t) => unit = "end";
-    [@bs.send] external endWithCallback: (Stream.t('data, [> kind ]), unit => unit) => unit = "end";
-    [@bs.send] external endWithDataCallback: (Stream.t('data, [> kind ]), Buffer.t, unit => unit) => unit = "end";
-    [@bs.send] external flushHeaders: Stream.t('data, [> kind ]) => unit = "flushHeaders";
-    [@bs.send] external getHeader: (Stream.t('data, [> kind ]), string) => 'a = "getHeader";
-    [@bs.send] external maxHeadersCount: Stream.t('data, [> kind ]) => int = "maxHeadersCount";
-    [@bs.send] external path: Stream.t('data, [> kind ]) => string = "path";
-    [@bs.send] external reusedSocket: Stream.t('data, [> kind ]) => bool = "reusedSocket";
-    [@bs.send] external setHeader: (Stream.t('data, [> kind ]), string, 'a) => unit = "setHeader";
-    [@bs.send] external setHeaderArray: (Stream.t('data, [> kind ]), string, array('a)) => unit = "setHeader";
-    [@bs.send] external setNoDelay: (Stream.t('data, [> kind ]), bool) => unit = "setNoDelay";
-    [@bs.send] external setSocketKeepAlive: (Stream.t('data, [> kind ]), bool) => unit = "setSocketKeepAlive";
-    [@bs.send] external setSocketKeepAliveWithDelay: (Stream.t('data, [> kind ]), bool, int) => unit = "setSocketKeepAlive";
-    [@bs.send] external setTimeout: (Stream.t('data, [> kind ]), int) => unit = "setTimeout";
-    [@bs.send] external setTimeoutWithCallback: (Stream.t('data, [> kind ]), int, unit => unit) => unit = "setTimeout";
-    [@bs.send] external socket: Stream.t('data, [> kind ]) => Stream.t('data, [> Net.Socket.kind ]) = "socket";
-    [@bs.send] external writableEnded: Stream.t('data, [> kind ]) => bool = "writableEnded";
-    [@bs.send] external write: (Stream.t('data, [> kind ]), Buffer.t) => bool = "write";
-    [@bs.send] external writeWithCallback: (Stream.t('data, [> kind ]), Buffer.t, unit => unit) => bool = "write";
+    [@bs.send] external abort: subtype('data, 'a) => unit = "abort";
+    [@bs.get] external aborted: subtype('data, 'a) => bool = "aborted";
+    [@bs.send] external end_: subtype('data, 'a) => unit = "end";
+    [@bs.send] external endWithData: (subtype('data, 'a), Buffer.t) => unit = "end";
+    [@bs.send] external endWithCallback: (subtype('data, 'a), unit => unit) => unit = "end";
+    [@bs.send] external endWithDataCallback: (subtype('data, 'a), Buffer.t, unit => unit) => unit = "end";
+    [@bs.send] external flushHeaders: subtype('data, 'a) => unit = "flushHeaders";
+    [@bs.send] external getHeader: (subtype('data, 'a), string) => 'any = "getHeader";
+    [@bs.send] external maxHeadersCount: subtype('data, 'a) => int = "maxHeadersCount";
+    [@bs.send] external path: subtype('data, 'a) => string = "path";
+    [@bs.send] external reusedSocket: subtype('data, 'a) => bool = "reusedSocket";
+    [@bs.send] external setHeader: (subtype('data, 'a), string, 'any) => unit = "setHeader";
+    [@bs.send] external setHeaderArray: (subtype('data, 'a), string, array('any)) => unit = "setHeader";
+    [@bs.send] external setNoDelay: (subtype('data, 'a), bool) => unit = "setNoDelay";
+    [@bs.send] external setSocketKeepAlive: (subtype('data, 'a), bool) => unit = "setSocketKeepAlive";
+    [@bs.send] external setSocketKeepAliveWithDelay: (subtype('data, 'a), bool, int) => unit = "setSocketKeepAlive";
+    [@bs.send] external setTimeout: (subtype('data, 'a), int) => unit = "setTimeout";
+    [@bs.send] external setTimeoutWithCallback: (subtype('data, 'a), int, unit => unit) => unit = "setTimeout";
+    [@bs.send] external socket: subtype('data, 'a) => Net.TcpSocket.t = "socket";
+    [@bs.send] external writableEnded: subtype('data, 'a) => bool = "writableEnded";
+    [@bs.send] external write: (subtype('data, 'a), Buffer.t) => bool = "write";
+    [@bs.send] external writeWithCallback: (subtype('data, 'a), Buffer.t, unit => unit) => bool = "write";
   };
 
   include Impl;
@@ -95,40 +93,42 @@ module ClientRequest = {
 
 module ServerResponse = {
   type kind = [ Stream.duplex | `ServerResponse ];
-  type t('data) = Stream.t('data, [ kind ]);
+  type subtype('data, 'a) = Stream.subtype('data, [> kind] as 'a);
+  type supertype('data, 'a) = Stream.subtype('data, [< kind] as 'a);
+  type t = subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Duplex.Impl;
-    [@bs.get] external statusCode: Stream.t('data, [> kind ]) => int = "statusCode";
-    [@bs.set] external setStatusCode: (Stream.t('data, [> kind ]), int) => unit = "statusCode";
-    [@bs.send] external write: (Stream.t('data, [> kind ]), Buffer.t) => bool = "write";
-    [@bs.send] external writeWithEncodingCallback: ( Stream.t('data, [> kind ]), Buffer.t, unit => unit) => bool = "write";
-    [@bs.send] external writeStatus: (Stream.t('data, [> kind ]), int) => unit = "writeHead";
-    [@bs.send] external cork: Stream.t('data, [> kind ]) => unit = "cork";
-    [@bs.send] external end_: Stream.t('data, [> kind ]) => unit = "end";
-    [@bs.send] external endWithData: (Stream.t('data, [> kind ]), Buffer.t) => unit = "end";
-    [@bs.send] external endWithCallback: (Stream.t('data, [> kind ]), unit => unit) => unit = "end";
-    [@bs.send] external endWithDataCallback: ( Stream.t('data, [> kind ]), Buffer.t, unit => unit) => unit = "end";
-    [@bs.send] external uncork: Stream.t('data, [> kind ]) => unit = "uncork";
-    [@bs.send] external flushHeaders: Stream.t('data, [> kind ]) => unit = "flushHeaders";
-    [@bs.send] external getHeader: (Stream.t('data, [> kind ]), string) => 'a = "getHeader";
-    [@bs.send] external getHeaderNames: Stream.t('data, [> kind ]) => array(string) = "getHeaderNames";
-    [@bs.send] external getHeaders: Stream.t('data, [> kind ]) => Js.t({..}) = "getHeaders";
-    [@bs.send] external hasHeader: (Stream.t('data, [> kind ]), string) => bool = "hasHeader";
-    [@bs.get] external headersSent: Stream.t('data, [> kind ]) => bool = "headersSent";
-    [@bs.send] external removeHeader: (Stream.t('data, [> kind ]), string) => unit = "removeHeader";
-    [@bs.get] external sendDate: Stream.t('data, [> kind ]) => bool = "sendDate";
-    [@bs.send] external setHeader: (Stream.t('data, [> kind ]), string, 'a) => unit = "setHeader";
-    [@bs.send] external setHeaderArray: (Stream.t('data, [> kind ]), string, array('a)) => unit = "setHeader";
-    [@bs.send] external setTimeout: (Stream.t('data, [> kind ]), int) => unit = "setTimeout";
-    [@bs.send] external setTimeoutWithCallback: (Stream.t('data, [> kind ]), int, unit => unit) => unit = "setTimeout";
-    [@bs.get] external socket: Stream.t('data, [> kind ]) => Net.TcpSocket.t = "socket";
-    [@bs.get] external statusMessage: Stream.t('data, [> kind ]) => string = "statusMessage";
-    [@bs.get] external writableEnded: Stream.t('data, [> kind ]) => bool = "writableEnded";
-    [@bs.get] external writableFinished: Stream.t('data, [> kind ]) => bool = "writableFinished";
-    [@bs.send] external writeContinue: Stream.t('data, [> kind ]) => unit = "writeContinue";
-    [@bs.send] external writeHead: (Stream.t('data, [> kind ] as 'a), int, Js.t({..})) => Stream.t('data, [> kind ] as 'a) = "writeHead";
-    [@bs.send] external writeHeadWithMessage: (Stream.t('data, [> kind ] as 'a), int, string, Js.t({..})) => Stream.t('data, [> kind ] as 'a) = "writeHead";
-    [@bs.send] external writeProcessing: Stream.t('data, [> kind ]) => unit = "writeProcessing";
+    [@bs.get] external statusCode: subtype('data, 'a) => int = "statusCode";
+    [@bs.set] external setStatusCode: (subtype('data, 'a), int) => unit = "statusCode";
+    [@bs.send] external write: (subtype('data, 'a), Buffer.t) => bool = "write";
+    [@bs.send] external writeWithEncodingCallback: ( subtype('data, 'a), Buffer.t, unit => unit) => bool = "write";
+    [@bs.send] external writeStatus: (subtype('data, 'a), int) => unit = "writeHead";
+    [@bs.send] external cork: subtype('data, 'a) => unit = "cork";
+    [@bs.send] external end_: subtype('data, 'a) => unit = "end";
+    [@bs.send] external endWithData: (subtype('data, 'a), Buffer.t) => unit = "end";
+    [@bs.send] external endWithCallback: (subtype('data, 'a), unit => unit) => unit = "end";
+    [@bs.send] external endWithDataCallback: ( subtype('data, 'a), Buffer.t, unit => unit) => unit = "end";
+    [@bs.send] external uncork: subtype('data, 'a) => unit = "uncork";
+    [@bs.send] external flushHeaders: subtype('data, 'a) => unit = "flushHeaders";
+    [@bs.send] external getHeader: (subtype('data, 'a), string) => 'any = "getHeader";
+    [@bs.send] external getHeaderNames: subtype('data, 'a) => array(string) = "getHeaderNames";
+    [@bs.send] external getHeaders: subtype('data, 'a) => Js.t({..}) = "getHeaders";
+    [@bs.send] external hasHeader: (subtype('data, 'a), string) => bool = "hasHeader";
+    [@bs.get] external headersSent: subtype('data, 'a) => bool = "headersSent";
+    [@bs.send] external removeHeader: (subtype('data, 'a), string) => unit = "removeHeader";
+    [@bs.get] external sendDate: subtype('data, 'a) => bool = "sendDate";
+    [@bs.send] external setHeader: (subtype('data, 'a), string, 'any) => unit = "setHeader";
+    [@bs.send] external setHeaderArray: (subtype('data, 'a), string, array('any)) => unit = "setHeader";
+    [@bs.send] external setTimeout: (subtype('data, 'a), int) => unit = "setTimeout";
+    [@bs.send] external setTimeoutWithCallback: (subtype('data, 'a), int, unit => unit) => unit = "setTimeout";
+    [@bs.get] external socket: subtype('data, 'a) => Net.TcpSocket.t = "socket";
+    [@bs.get] external statusMessage: subtype('data, 'a) => string = "statusMessage";
+    [@bs.get] external writableEnded: subtype('data, 'a) => bool = "writableEnded";
+    [@bs.get] external writableFinished: subtype('data, 'a) => bool = "writableFinished";
+    [@bs.send] external writeContinue: subtype('data, 'a) => unit = "writeContinue";
+    [@bs.send] external writeHead: (subtype('data, 'a), int, Js.t({..})) => subtype('data, 'a) = "writeHead";
+    [@bs.send] external writeHeadWithMessage: (subtype('data, 'a), int, string, Js.t({..})) => subtype('data, 'a) = "writeHead";
+    [@bs.send] external writeProcessing: subtype('data, 'a) => unit = "writeProcessing";
   };
 
   include Impl;
@@ -138,8 +138,8 @@ module Agent = {
   type t;
   [@bs.send] external createConnection: (t, Js.t({..})) => Net.TcpSocket.t = "createConnection";
   [@bs.send] external createConnectionWithCallback: (t, Js.t({..}), unit => unit) => Net.TcpSocket.t = "createConnection";
-  [@bs.send] external keepSocketAlive: (t, Stream.t('data, [> Net.Socket.kind ])) => unit = "keepSocketAlive";
-  [@bs.send] external reuseSocket: (t, Stream.t('data, [> Net.Socket.kind ]), Stream.t('data, [> ClientRequest.kind ])) => unit = "reuseSocket";
+  [@bs.send] external keepSocketAlive: (t, Net.TcpSocket.t) => unit = "keepSocketAlive";
+  [@bs.send] external reuseSocket: (t, Net.TcpSocket.t, ClientRequest.t) => unit = "reuseSocket";
   [@bs.send] external destroy: t => unit = "destroy";
   [@bs.get] external freeSockets: t => Js.t({..}) = "freeSockets";
   [@bs.send] external getName: (t, Js.t({..})) => string = "getName";
@@ -169,8 +169,8 @@ type createServerOptions;
 [@bs.obj]
 external createServerOptions:
   (
-    ~incomingMessage: Stream.t(Buffer.t, [> IncomingMessage.kind ])=?,
-    ~serverResponse: Stream.t(Buffer.t, [> ServerResponse.kind ])=?,
+    ~incomingMessage: IncomingMessage.t=?,
+    ~serverResponse: ServerResponse.t=?,
     ~maxHeaderSize: int=?,
     unit
   ) =>
@@ -178,12 +178,12 @@ external createServerOptions:
   "";
 
 [@bs.module "http"]
-external createServer: ((Stream.t(Buffer.t, [> IncomingMessage.kind ]), Stream.t(Buffer.t, [> ServerResponse.kind ])) => unit) => Server.t =
+external createServer: ((IncomingMessage.t, ServerResponse.t) => unit) => Server.t =
   "createServer";
 
 [@bs.module "http"]
 external createServerWithOptions:
-  (createServerOptions, (Stream.t(Buffer.t, [> IncomingMessage.kind ]), Stream.t(Buffer.t, [> ServerResponse.kind ])) => unit) => Server.t =
+  (createServerOptions, (IncomingMessage.t, ServerResponse.t) => unit) => Server.t =
   "createServer";
 
 [@bs.module "http"] external _METHODS: array(string) = "METHODS";
@@ -216,23 +216,23 @@ external requestOptions:
   "";
 
 [@bs.module "http"] external request: string => ClientRequest.t = "request";
-[@bs.module "http"] external requestWithCallback: (string, Stream.t(Buffer.t, [> IncomingMessage.kind ]) => unit) => ClientRequest.t = "request";
+[@bs.module "http"] external requestWithCallback: (string, IncomingMessage.t => unit) => ClientRequest.t = "request";
 [@bs.module "http"] external requestWithOptions: (string, requestOptions) => ClientRequest.t = "request";
-[@bs.module "http"] external requestWithOptionsCallback: (string, requestOptions, Stream.t(Buffer.t, [> IncomingMessage.kind ]) => unit) => ClientRequest.t = "request";
+[@bs.module "http"] external requestWithOptionsCallback: (string, requestOptions, IncomingMessage.t => unit) => ClientRequest.t = "request";
 [@bs.module "http"] external requestUrl: Url.t => ClientRequest.t = "request";
-[@bs.module "http"] external requestUrlWithCallback: (Url.t, Stream.t(Buffer.t, [> IncomingMessage.kind ]) => unit) => ClientRequest.t = "request";
+[@bs.module "http"] external requestUrlWithCallback: (Url.t, IncomingMessage.t => unit) => ClientRequest.t = "request";
 [@bs.module "http"] external requestUrlWithOptions: (Url.t, requestOptions) => ClientRequest.t = "request";
-[@bs.module "http"] external requestUrlWithOptionsCallback: (Url.t, requestOptions, Stream.t(Buffer.t, [> IncomingMessage.kind ]) => unit) => ClientRequest.t = "request";
+[@bs.module "http"] external requestUrlWithOptionsCallback: (Url.t, requestOptions, IncomingMessage.t => unit) => ClientRequest.t = "request";
 
 [@bs.module "http"] external get: string => ClientRequest.t = "get";
-[@bs.module "http"] external getWithCallback: (string, Stream.t(Buffer.t, [> IncomingMessage.kind ]) => unit) => ClientRequest.t = "get";
+[@bs.module "http"] external getWithCallback: (string, IncomingMessage.t => unit) => ClientRequest.t = "get";
 [@bs.module "http"] external getWithOptions: (string, requestOptions) => ClientRequest.t = "get";
-[@bs.module "http"] external getWithOptionsCallback: (string, requestOptions, Stream.t(Buffer.t, [> IncomingMessage.kind ]) => unit) => ClientRequest.t = "get";
+[@bs.module "http"] external getWithOptionsCallback: (string, requestOptions, IncomingMessage.t => unit) => ClientRequest.t = "get";
 
 [@bs.module "http"] external getUrl: Url.t => ClientRequest.t = "get";
-[@bs.module "http"] external getUrlWithCallback: (Url.t, Stream.t(Buffer.t, [> IncomingMessage.kind ]) => unit) => ClientRequest.t = "get";
+[@bs.module "http"] external getUrlWithCallback: (Url.t, IncomingMessage.t => unit) => ClientRequest.t = "get";
 [@bs.module "http"] external getUrlWithOptions: (Url.t, requestOptions) => ClientRequest.t = "get";
-[@bs.module "http"] external getUrlWithOptionsCallback: (Url.t, requestOptions, Stream.t(Buffer.t, [> IncomingMessage.kind ]) => unit) => ClientRequest.t = "get";
+[@bs.module "http"] external getUrlWithOptionsCallback: (Url.t, requestOptions, IncomingMessage.t => unit) => ClientRequest.t = "get";
 
 [@bs.module "http"] external globalAgent: Agent.t = "globalAgent";
 [@bs.module "http"] external maxHeaderSize: int = "maxHeaderSize";

--- a/src/Http.re
+++ b/src/Http.re
@@ -216,38 +216,33 @@ module Server = {
   type subtype('a) = Net.Server.subtype([> kind ] as 'a);
   type supertype('a) = Net.Server.subtype([< kind ] as 'a);
   type t = subtype(kind);
-  module Events = {
-    [@bs.send] external onCheckContinue: (subtype('a), [@bs.as "checkContinue"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "on";
-    [@bs.send] external onCheckExpectation: (subtype('a), [@bs.as "checkExpectation"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "on";
-    [@bs.send] external onClose: (subtype('a), [@bs.as "close"] _, (. unit) => unit) => subtype('a) = "on";
-    [@bs.send] external onClientError: (subtype('a), [@bs.as "clientError"] _, (. Js.Exn.t, Net.TcpSocket.t) => unit) => subtype('a) = "on";
-    [@bs.send] external onConnect: (subtype('a), [@bs.as "connect"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => subtype('a) = "on";
-    [@bs.send] external onConnection: (subtype('a), [@bs.as "connection"] _, (. Net.TcpSocket.t) => unit) => subtype('a) = "on";
-    [@bs.send] external onRequest: (subtype('a), [@bs.as "request"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "on";
-    [@bs.send] external onUpgrade: (subtype('a), [@bs.as "upgrade"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => subtype('a) = "on";
-
-    [@bs.send] external offCheckContinue: (subtype('a), [@bs.as "checkContinue"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "off";
-    [@bs.send] external offCheckExpectation: (subtype('a), [@bs.as "checkExpectation"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "off";
-    [@bs.send] external offClose: (subtype('a), [@bs.as "close"] _, (. unit) => unit) => subtype('a) = "off";
-    [@bs.send] external offClientError: (subtype('a), [@bs.as "clientError"] _, (. Js.Exn.t, Net.TcpSocket.t) => unit) => subtype('a) = "off";
-    [@bs.send] external offConnect: (subtype('a), [@bs.as "connect"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => subtype('a) = "off";
-    [@bs.send] external offConnection: (subtype('a), [@bs.as "connection"] _, (. Net.TcpSocket.t) => unit) => subtype('a) = "off";
-    [@bs.send] external offRequest: (subtype('a), [@bs.as "request"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "off";
-    [@bs.send] external offUpgrade: (subtype('a), [@bs.as "upgrade"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => subtype('a) = "off";
-
-    [@bs.send] external onCheckContinueOnce: (subtype('a), [@bs.as "checkContinue"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "once";
-    [@bs.send] external onCheckExpectationOnce: (subtype('a), [@bs.as "checkExpectation"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "once";
-    [@bs.send] external onCloseOnce: (subtype('a), [@bs.as "close"] _, (. unit) => unit) => subtype('a) = "once";
-    [@bs.send] external onClientErrorOnce: (subtype('a), [@bs.as "clientError"] _, (. Js.Exn.t, Net.TcpSocket.t) => unit) => subtype('a) = "once";
-    [@bs.send] external onConnectOnce: (subtype('a), [@bs.as "connect"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => subtype('a) = "once";
-    [@bs.send] external onConnectionOnce: (subtype('a), [@bs.as "connection"] _, (. Net.TcpSocket.t) => unit) => subtype('a) = "once";
-    [@bs.send] external onRequestOnce: (subtype('a), [@bs.as "request"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "once";
-    [@bs.send] external onUpgradeOnce: (subtype('a), [@bs.as "upgrade"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => subtype('a) = "once";
+  module Events = (T: { type t; }) => {
+    include Net.TcpServer.Events(T);
+    [@bs.send] external onCheckContinue: (T.t, [@bs.as "checkContinue"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "on";
+    [@bs.send] external onCheckExpectation: (T.t, [@bs.as "checkExpectation"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "on";
+    [@bs.send] external onClientError: (T.t, [@bs.as "clientError"] _, (. Js.Exn.t, Net.TcpSocket.t) => unit) => T.t = "on";
+    [@bs.send] external onConnect: (T.t, [@bs.as "connect"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => T.t = "on";
+    [@bs.send] external onRequest: (T.t, [@bs.as "request"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "on";
+    [@bs.send] external onUpgrade: (T.t, [@bs.as "upgrade"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => T.t = "on";
+    [@bs.send] external onTimeout: (T.t, [@bs.as "timeout"] _, (. Net.TcpSocket.t) => unit) => T.t = "on";
+    [@bs.send] external offCheckContinue: (T.t, [@bs.as "checkContinue"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "off";
+    [@bs.send] external offCheckExpectation: (T.t, [@bs.as "checkExpectation"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "off";
+    [@bs.send] external offClientError: (T.t, [@bs.as "clientError"] _, (. Js.Exn.t, Net.TcpSocket.t) => unit) => T.t = "off";
+    [@bs.send] external offConnect: (T.t, [@bs.as "connect"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => T.t = "off";
+    [@bs.send] external offRequest: (T.t, [@bs.as "request"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "off";
+    [@bs.send] external offUpgrade: (T.t, [@bs.as "upgrade"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => T.t = "off";
+    [@bs.send] external offTimeout: (T.t, [@bs.as "timeout"] _, (. Net.TcpSocket.t) => unit) => T.t = "off";
+    [@bs.send] external onCheckContinueOnce: (T.t, [@bs.as "checkContinue"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "once";
+    [@bs.send] external onCheckExpectationOnce: (T.t, [@bs.as "checkExpectation"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "once";
+    [@bs.send] external onClientErrorOnce: (T.t, [@bs.as "clientError"] _, (. Js.Exn.t, Net.TcpSocket.t) => unit) => T.t = "once";
+    [@bs.send] external onConnectOnce: (T.t, [@bs.as "connect"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => T.t = "once";
+    [@bs.send] external onRequestOnce: (T.t, [@bs.as "request"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "once";
+    [@bs.send] external onUpgradeOnce: (T.t, [@bs.as "upgrade"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => T.t = "once";
+    [@bs.send] external onTimeoutOnce: (T.t, [@bs.as "timeout"] _, (. Net.TcpSocket.t) => unit) => T.t = "once";
   };
   module Impl = (T: { type t; }) => {
-    include Events;
-    [@bs.send] external setTimeout: (T.t, int) => T.t = "setTimeout";
-    [@bs.send] external setTimeoutWithCallback: (T.t, int, unit => unit) => T.t = "setTimeout";
+    include Events(T);
+    [@bs.send] external setTimeout: (T.t, int, (. Net.TcpSocket.t) => unit) => unit = "setTimeout";
     [@bs.get] external timeout: T.t => int = "timeout";
     [@bs.send] external keepAliveTimeout: (T.t, int) => unit = "keepAliveTimeout";
     include Net.TcpServer.Impl(T);

--- a/src/Http.re
+++ b/src/Http.re
@@ -216,38 +216,38 @@ module Server = {
   type subtype('a) = Net.Server.subtype([> kind ] as 'a);
   type supertype('a) = Net.Server.subtype([< kind ] as 'a);
   type t = subtype(kind);
-  module Events = (T: { type t; }) => {
-    include Net.TcpServer.Events(T);
-    [@bs.send] external onCheckContinue: (T.t, [@bs.as "checkContinue"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "on";
-    [@bs.send] external onCheckExpectation: (T.t, [@bs.as "checkExpectation"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "on";
-    [@bs.send] external onClientError: (T.t, [@bs.as "clientError"] _, (. Js.Exn.t, Net.TcpSocket.t) => unit) => T.t = "on";
-    [@bs.send] external onConnect: (T.t, [@bs.as "connect"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => T.t = "on";
-    [@bs.send] external onRequest: (T.t, [@bs.as "request"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "on";
-    [@bs.send] external onUpgrade: (T.t, [@bs.as "upgrade"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => T.t = "on";
-    [@bs.send] external onTimeout: (T.t, [@bs.as "timeout"] _, (. Net.TcpSocket.t) => unit) => T.t = "on";
-    [@bs.send] external offCheckContinue: (T.t, [@bs.as "checkContinue"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "off";
-    [@bs.send] external offCheckExpectation: (T.t, [@bs.as "checkExpectation"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "off";
-    [@bs.send] external offClientError: (T.t, [@bs.as "clientError"] _, (. Js.Exn.t, Net.TcpSocket.t) => unit) => T.t = "off";
-    [@bs.send] external offConnect: (T.t, [@bs.as "connect"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => T.t = "off";
-    [@bs.send] external offRequest: (T.t, [@bs.as "request"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "off";
-    [@bs.send] external offUpgrade: (T.t, [@bs.as "upgrade"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => T.t = "off";
-    [@bs.send] external offTimeout: (T.t, [@bs.as "timeout"] _, (. Net.TcpSocket.t) => unit) => T.t = "off";
-    [@bs.send] external onCheckContinueOnce: (T.t, [@bs.as "checkContinue"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "once";
-    [@bs.send] external onCheckExpectationOnce: (T.t, [@bs.as "checkExpectation"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "once";
-    [@bs.send] external onClientErrorOnce: (T.t, [@bs.as "clientError"] _, (. Js.Exn.t, Net.TcpSocket.t) => unit) => T.t = "once";
-    [@bs.send] external onConnectOnce: (T.t, [@bs.as "connect"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => T.t = "once";
-    [@bs.send] external onRequestOnce: (T.t, [@bs.as "request"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => T.t = "once";
-    [@bs.send] external onUpgradeOnce: (T.t, [@bs.as "upgrade"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => T.t = "once";
-    [@bs.send] external onTimeoutOnce: (T.t, [@bs.as "timeout"] _, (. Net.TcpSocket.t) => unit) => T.t = "once";
+  module Events = {
+    include Net.TcpServer.Events;
+    [@bs.send] external onCheckContinue: (subtype('a), [@bs.as "checkContinue"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "on";
+    [@bs.send] external onCheckExpectation: (subtype('a), [@bs.as "checkExpectation"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "on";
+    [@bs.send] external onClientError: (subtype('a), [@bs.as "clientError"] _, (. Js.Exn.t, Net.TcpSocket.t) => unit) => subtype('a) = "on";
+    [@bs.send] external onConnect: (subtype('a), [@bs.as "connect"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => subtype('a) = "on";
+    [@bs.send] external onRequest: (subtype('a), [@bs.as "request"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "on";
+    [@bs.send] external onUpgrade: (subtype('a), [@bs.as "upgrade"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => subtype('a) = "on";
+    [@bs.send] external onTimeout: (subtype('a), [@bs.as "timeout"] _, (. Net.TcpSocket.t) => unit) => subtype('a) = "on";
+    [@bs.send] external offCheckContinue: (subtype('a), [@bs.as "checkContinue"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "off";
+    [@bs.send] external offCheckExpectation: (subtype('a), [@bs.as "checkExpectation"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "off";
+    [@bs.send] external offClientError: (subtype('a), [@bs.as "clientError"] _, (. Js.Exn.t, Net.TcpSocket.t) => unit) => subtype('a) = "off";
+    [@bs.send] external offConnect: (subtype('a), [@bs.as "connect"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => subtype('a) = "off";
+    [@bs.send] external offRequest: (subtype('a), [@bs.as "request"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "off";
+    [@bs.send] external offUpgrade: (subtype('a), [@bs.as "upgrade"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => subtype('a) = "off";
+    [@bs.send] external offTimeout: (subtype('a), [@bs.as "timeout"] _, (. Net.TcpSocket.t) => unit) => subtype('a) = "off";
+    [@bs.send] external onCheckContinueOnce: (subtype('a), [@bs.as "checkContinue"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "once";
+    [@bs.send] external onCheckExpectationOnce: (subtype('a), [@bs.as "checkExpectation"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "once";
+    [@bs.send] external onClientErrorOnce: (subtype('a), [@bs.as "clientError"] _, (. Js.Exn.t, Net.TcpSocket.t) => unit) => subtype('a) = "once";
+    [@bs.send] external onConnectOnce: (subtype('a), [@bs.as "connect"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => subtype('a) = "once";
+    [@bs.send] external onRequestOnce: (subtype('a), [@bs.as "request"] _, (. IncomingMessage.t, ServerResponse.t) => unit) => subtype('a) = "once";
+    [@bs.send] external onUpgradeOnce: (subtype('a), [@bs.as "upgrade"] _, (. IncomingMessage.t, Net.TcpSocket.t, Js.nullable(Buffer.t)) => unit) => subtype('a) = "once";
+    [@bs.send] external onTimeoutOnce: (subtype('a), [@bs.as "timeout"] _, (. Net.TcpSocket.t) => unit) => subtype('a) = "once";
   };
-  module Impl = (T: { type t; }) => {
-    include Events(T);
-    [@bs.send] external setTimeout: (T.t, int, (. Net.TcpSocket.t) => unit) => unit = "setTimeout";
-    [@bs.get] external timeout: T.t => int = "timeout";
-    [@bs.send] external keepAliveTimeout: (T.t, int) => unit = "keepAliveTimeout";
-    include Net.TcpServer.Impl(T);
+  module Impl = {
+    include Events;
+    [@bs.send] external setTimeout: (subtype('a), int, (. Net.TcpSocket.t) => unit) => unit = "setTimeout";
+    [@bs.get] external timeout: subtype('a) => int = "timeout";
+    [@bs.send] external keepAliveTimeout: (subtype('a), int) => unit = "keepAliveTimeout";
+    include Net.TcpServer.Impl;
   };
-  include Impl({ type nonrec t = t; });
+  include Impl;
 };
 
 type createServerOptions;

--- a/src/Http2.re
+++ b/src/Http2.re
@@ -48,25 +48,27 @@ module ServerHttp2Stream = {
 
 module Http2Session = {
   type t;
-  [@bs.send] external onClose: (t, [@bs.as "close"] _, unit => unit) => unit = "on";
-  [@bs.send] external onConnect: (t, [@bs.as "connect"] _, (t, Stream.subtype(Buffer.t, [> Net.Socket.kind ])) => unit) => unit = "on";
-  [@bs.send] external onError: (t, [@bs.as "error"] _, Js.Exn.t => unit) => unit = "on";
-  [@bs.send] external onFrameError: (t, [@bs.as "frameError"] _, (~type_:int, ~errorCode:int, ~streamId:int) => unit) => unit = "on";
-  [@bs.send] external onGoAway: (t, [@bs.as "goAway"] _, (~errorCode:int, ~lastStreamId:int, Buffer.t) => unit) => unit = "on";
-  [@bs.send] external onLocalSettings: (t, [@bs.as "localSettings"] _, settingsObject => unit) => unit = "on";
-  [@bs.send] external onPing: (t, [@bs.as "ping"] _, Buffer.t => unit) => unit = "on";
-  [@bs.send] external onRemoteSettings: (t, [@bs.as "remoteSettings"] _, settingsObject => unit) => unit = "on";
+  [@bs.send] external onClose: (t, [@bs.as "close"] _, (. unit) => unit) => t = "on";
+  [@bs.send] external onConnect: (t, [@bs.as "connect"] _, (. t, Stream.subtype(Buffer.t, [> Net.Socket.kind ])) => unit) => t = "on";
+  [@bs.send] external onError: (t, [@bs.as "error"] _, (. Js.Exn.t) => unit) => t = "on";
+  /** TODO: uncurry after release of bs-platform v7.3 */
+  [@bs.send] external onFrameError: (t, [@bs.as "frameError"] _, (~type_:int, ~errorCode:int, ~streamId:int) => unit) => t = "on";
+  /** TODO: uncurry after release of bs-platform v7.3 */
+  [@bs.send] external onGoAway: (t, [@bs.as "goAway"] _, (~errorCode:int, ~lastStreamId:int, Buffer.t) => unit) => t = "on";
+  [@bs.send] external onLocalSettings: (t, [@bs.as "localSettings"] _, (. settingsObject) => unit) => t = "on";
+  [@bs.send] external onPing: (t, [@bs.as "ping"] _, (. Buffer.t) => unit) => t = "on";
+  [@bs.send] external onRemoteSettings: (t, [@bs.as "remoteSettings"] _, (. settingsObject) => unit) => t = "on";
   [@bs.send] external onStream: (
       t,
       [@bs.as "stream"] _,
-      (
+      (.
         Stream.subtype(Buffer.t, [> Http2Stream.kind ]),
         Js.t({.. "status": string, "content-type": string}),
         int,
         array(Js.t({..}))
       ) => unit
-    ) => unit = "on";
-  [@bs.send] external onTimeout: (t, [@bs.as "timeout"] _, unit => unit) => unit = "on";
+    ) => t = "on";
+  [@bs.send] external onTimeout: (t, [@bs.as "timeout"] _, (. unit) => unit) => t = "on";
   [@bs.get] [@bs.return nullable] external alpnProtocol: t => option(string) = "alpnProtocol";
   [@bs.send] external close: t => unit = "close";
   [@bs.get] external closed: t => bool = "closed";
@@ -153,8 +155,8 @@ module Http2ServerRequest = {
   type t = Stream.subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Readable.Impl;
-    [@bs.send] external onAborted: (t, [@bs.as "aborted"] _, unit => unit) => unit = "on";
-    [@bs.send] external onClose: (t, [@bs.as "close"] _, unit => unit) => unit = "on";
+    [@bs.send] external onAborted: (t, [@bs.as "aborted"] _, (. unit) => unit) => t = "on";
+    [@bs.send] external onClose: (t, [@bs.as "close"] _, (. unit) => unit) => t = "on";
     [@bs.get] external aborted: t => bool = "aborted";
     [@bs.get] external authority: t => string = "authority";
     [@bs.get] external complete: t => bool = "complete";
@@ -180,8 +182,8 @@ module Http2ServerResponse = {
   type t = Stream.subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Duplex.Impl;
-    [@bs.send] external onClose: (t, [@bs.as "close"] _, unit => unit) => unit = "on";
-    [@bs.send] external onFinish: (t, [@bs.as "finish"] _, unit => unit) => unit = "on";
+    [@bs.send] external onClose: (t, [@bs.as "close"] _, (. unit) => unit) => t = "on";
+    [@bs.send] external onFinish: (t, [@bs.as "finish"] _, (. unit) => unit) => t = "on";
     [@bs.send] external setTrailers: (t, Js.t({..})) => unit = "setTrailers";
     [@bs.send] external end_: t => unit = "end";
     [@bs.send] external endWith: ( t, ~data: Buffer.t=?, ~callback: unit => unit=?) => t = "end";

--- a/src/Http2.re
+++ b/src/Http2.re
@@ -18,7 +18,7 @@ type settingsObject;
 
 module Http2Stream = {
   type kind = [ Stream.duplex | `Http2Stream ];
-  type t = Stream.t(Buffer.t, [ kind ]);
+  type t = Stream.subtype(Buffer.t, kind);
   module Impl = {
     include Stream.Duplex.Impl;
 
@@ -28,7 +28,7 @@ module Http2Stream = {
 
 module ClientHttp2Stream = {
   type kind = [ Http2Stream.kind | `ClientHttp2Stream ];
-  type t = Stream.t(Buffer.t, [ kind ]);
+  type t = Stream.subtype(Buffer.t, kind);
   module Impl = {
     include Http2Stream.Impl;
 
@@ -38,7 +38,7 @@ module ClientHttp2Stream = {
 
 module ServerHttp2Stream = {
   type kind = [ Http2Stream.kind | `ServerHttp2Stream ];
-  type t = Stream.t(Buffer.t, [ kind ]);
+  type t = Stream.subtype(Buffer.t, kind);
   module Impl = {
     include Http2Stream.Impl;
 
@@ -49,7 +49,7 @@ module ServerHttp2Stream = {
 module Http2Session = {
   type t;
   [@bs.send] external onClose: (t, [@bs.as "close"] _, unit => unit) => unit = "on";
-  [@bs.send] external onConnect: (t, [@bs.as "connect"] _, (t, Stream.t(Buffer.t, [> Net.Socket.kind ])) => unit) => unit = "on";
+  [@bs.send] external onConnect: (t, [@bs.as "connect"] _, (t, Stream.subtype(Buffer.t, [> Net.Socket.kind ])) => unit) => unit = "on";
   [@bs.send] external onError: (t, [@bs.as "error"] _, Js.Exn.t => unit) => unit = "on";
   [@bs.send] external onFrameError: (t, [@bs.as "frameError"] _, (~type_:int, ~errorCode:int, ~streamId:int) => unit) => unit = "on";
   [@bs.send] external onGoAway: (t, [@bs.as "goAway"] _, (~errorCode:int, ~lastStreamId:int, Buffer.t) => unit) => unit = "on";
@@ -60,7 +60,7 @@ module Http2Session = {
       t,
       [@bs.as "stream"] _,
       (
-        Stream.t(Buffer.t, [> Http2Stream.kind ]),
+        Stream.subtype(Buffer.t, [> Http2Stream.kind ]),
         Js.t({.. "status": string, "content-type": string}),
         int,
         array(Js.t({..}))
@@ -150,7 +150,7 @@ module ServerHttp2Session = {
 
 module Http2ServerRequest = {
   type kind = [ Stream.readable | `Http2ServerRequest ];
-  type t = Stream.t(Buffer.t, [ kind ]);
+  type t = Stream.subtype(Buffer.t, [ kind ]);
   module Impl = {
     include Stream.Readable.Impl;
     [@bs.send] external onAborted: (t, [@bs.as "aborted"] _, unit => unit) => unit = "on";
@@ -167,7 +167,7 @@ module Http2ServerRequest = {
     [@bs.get] external rawTrailers: t => array(string) = "rawTrailers";
     [@bs.get] external scheme: t => string = "scheme";
     [@bs.send] external setTimeout: (t, int, Http2Stream.t => unit) => Http2Stream.t = "setTimeout";
-    [@bs.get] external socket: t => Stream.t(Buffer.t, [ Stream.duplex | `Socket | `TLSSocket ]) = "socket";
+    [@bs.get] external socket: t => Stream.subtype(Buffer.t, [ Stream.duplex | `Socket | `TLSSocket ]) = "socket";
     [@bs.get] external stream: t => Http2Stream.t = "stream";
     [@bs.get] external trailers: t => Js.t({..}) = "trailers";
     [@bs.get] external url: t => string = "url";
@@ -176,43 +176,37 @@ module Http2ServerRequest = {
 };
 
 module Http2ServerResponse = {
-
   type kind = [ Stream.duplex | `Http2ServerResponse ];
-  type t = Stream.t(Buffer.t, [ kind ]);
-
+  type t = Stream.subtype(Buffer.t, [ kind ]);
   module Impl = {
-
     include Stream.Duplex.Impl;
-
-    [@bs.send] external onClose: (Stream.t(Buffer.t, [> kind ]), [@bs.as "close"] _, unit => unit) => unit = "on";
-    [@bs.send] external onFinish: (Stream.t(Buffer.t, [> kind ]), [@bs.as "finish"] _, unit => unit) => unit = "on";
-    [@bs.send] external setTrailers: (Stream.t(Buffer.t, [> kind ]), Js.t({..})) => unit = "setTrailers";
-    [@bs.send] external end_: Stream.t(Buffer.t, [> kind ]) => unit = "end";
-    [@bs.send] external endWith: ( Stream.t(Buffer.t, [> kind ]), ~data: Buffer.t=?, ~callback: unit => unit=?) => t = "end";
-    [@bs.send] external getHeader: (Stream.t(Buffer.t, [> kind ]), string) => string = "getHeader";
-    [@bs.send] external getHeaderNames: Stream.t(Buffer.t, [> kind ]) => array(string) = "getHeaderNames";
-    [@bs.send] external getHeaders: Stream.t(Buffer.t, [> kind ]) => Js.t({..}) = "getHeaders";
-    [@bs.send] external hasHeader: (Stream.t(Buffer.t, [> kind ]), string) => bool = "hasHeader";
-    [@bs.send] external headersSent: Stream.t(Buffer.t, [> kind ]) => bool = "headersSent";
-    [@bs.send] external removeHeader: (Stream.t(Buffer.t, [> kind ]), string) => unit = "removeHeader";
-    [@bs.send] external setHeader: (Stream.t(Buffer.t, [> kind ]), string) => unit = "setHeader";
-    [@bs.send] external setHeaderArray: (Stream.t(Buffer.t, [> kind ]), array(string)) => unit = "setHeader";
-    [@bs.send] external setTimeout: (Stream.t(Buffer.t, [> kind ]), int, Http2Stream.t => unit) => Http2Stream.t = "setTimeout";
-    [@bs.get] external socket: Stream.t(Buffer.t, [> kind ]) => Net.TcpSocket.t = "socket";
-    [@bs.get] external statusCode: Stream.t(Buffer.t, [> kind ]) => int = "statusCode";
-    [@bs.get] external statusMessage: Stream.t(Buffer.t, [> kind ]) => string = "statusMessage";
-    [@bs.get] external stream: Stream.t(Buffer.t, [> kind ]) => Http2Stream.t = "stream";
-    [@bs.get] external writableEnded: Stream.t(Buffer.t, [> kind ]) => bool = "writableEnded";
-    [@bs.send] external write: ( Stream.t(Buffer.t, [> kind ]), Buffer.t) => bool = "write";
-    [@bs.send] external writeWith: ( Stream.t(Buffer.t, [> kind ]), Buffer.t, ~callback: unit => unit=?) => bool = "write";
-    [@bs.send] external writeContinue: Stream.t(Buffer.t, [> kind ]) => unit = "writeContinue";
-    [@bs.send] external writeHead: (Stream.t(Buffer.t, [> kind ] as 'a), int) => Stream.t(Buffer.t, [> kind ] as 'a) = "writeHead";
-    [@bs.send] external writeHeadWith: (Stream.t(Buffer.t, [> kind ] as 'a), int, ~message: string=?, ~headers: Js.t({..})=?) => Stream.t(Buffer.t, [> kind ] as 'a) = "writeHead";
-    [@bs.send] external createPushResponse: (Stream.t(Buffer.t, [> kind ]), Js.t({..}), (Js.Exn.t, ServerHttp2Stream.t) => unit) => unit = "writeHead";
+    [@bs.send] external onClose: (t, [@bs.as "close"] _, unit => unit) => unit = "on";
+    [@bs.send] external onFinish: (t, [@bs.as "finish"] _, unit => unit) => unit = "on";
+    [@bs.send] external setTrailers: (t, Js.t({..})) => unit = "setTrailers";
+    [@bs.send] external end_: t => unit = "end";
+    [@bs.send] external endWith: ( t, ~data: Buffer.t=?, ~callback: unit => unit=?) => t = "end";
+    [@bs.send] external getHeader: (t, string) => string = "getHeader";
+    [@bs.send] external getHeaderNames: t => array(string) = "getHeaderNames";
+    [@bs.send] external getHeaders: t => Js.t({..}) = "getHeaders";
+    [@bs.send] external hasHeader: (t, string) => bool = "hasHeader";
+    [@bs.send] external headersSent: t => bool = "headersSent";
+    [@bs.send] external removeHeader: (t, string) => unit = "removeHeader";
+    [@bs.send] external setHeader: (t, string) => unit = "setHeader";
+    [@bs.send] external setHeaderArray: (t, array(string)) => unit = "setHeader";
+    [@bs.send] external setTimeout: (t, int, Http2Stream.t => unit) => Http2Stream.t = "setTimeout";
+    [@bs.get] external socket: t => Net.TcpSocket.t = "socket";
+    [@bs.get] external statusCode: t => int = "statusCode";
+    [@bs.get] external statusMessage: t => string = "statusMessage";
+    [@bs.get] external stream: t => Http2Stream.t = "stream";
+    [@bs.get] external writableEnded: t => bool = "writableEnded";
+    [@bs.send] external write: ( t, Buffer.t) => bool = "write";
+    [@bs.send] external writeWith: ( t, Buffer.t, ~callback: unit => unit=?) => bool = "write";
+    [@bs.send] external writeContinue: t => unit = "writeContinue";
+    [@bs.send] external writeHead: (t, int) => t = "writeHead";
+    [@bs.send] external writeHeadWith: (t, int, ~message: string=?, ~headers: Js.t({..})=?) => t = "writeHead";
+    [@bs.send] external createPushResponse: (t, Js.t({..}), (Js.Exn.t, ServerHttp2Stream.t) => unit) => unit = "writeHead";
 
   };
-
   include Impl;
-
 };
 

--- a/src/Https.re
+++ b/src/Https.re
@@ -13,6 +13,6 @@ module HttpsServer = {
 
 module Agent = {
   type t;
-  [@bs.send] external onKeylog: (t, [@bs.as "keylog"]_, (Buffer.t, Tls.TlsSocket.t)) => unit = "on";
+  [@bs.send] external onKeylog: (t, [@bs.as "keylog"]_, (. Buffer.t, Tls.TlsSocket.t) => unit) => t = "on";
 };
 

--- a/src/Https.re
+++ b/src/Https.re
@@ -5,13 +5,10 @@ module HttpsServer = {
   type subtype('a) = Net.Socket.subtype([> kind ] as 'a);
   type supertype('a) = Net.Socket.subtype([< kind ] as 'a);
   type t = subtype(kind);
-
-  module Impl = (T: { type t; }) => {
-    include Tls.TlsServer.Impl(T);
+  module Impl = {
+    include Tls.TlsServer.Impl;
   };
-
-  include Impl({ type nonrec t = t; });
-
+  include Impl;
 };
 
 module Agent = {

--- a/src/Https.re
+++ b/src/Https.re
@@ -5,8 +5,12 @@ module HttpsServer = {
   type subtype('a) = Net.Server.subtype([> kind ] as 'a);
   type supertype('a) = Net.Server.subtype([< kind ] as 'a);
   type t = subtype(kind);
+  module Events = {
+    include Tls.TlsServer.Events;
+  };
   module Impl = {
     include Tls.TlsServer.Impl;
+    include Events;
   };
   include Impl;
 };
@@ -14,5 +18,7 @@ module HttpsServer = {
 module Agent = {
   type t;
   [@bs.send] external onKeylog: (t, [@bs.as "keylog"]_, (. Buffer.t, Tls.TlsSocket.t) => unit) => t = "on";
+  [@bs.send] external onKeylogOnce: (t, [@bs.as "keylog"]_, (. Buffer.t, Tls.TlsSocket.t) => unit) => t = "once";
+  [@bs.send] external offKeylog: (t, [@bs.as "keylog"]_, (. Buffer.t, Tls.TlsSocket.t) => unit) => t = "off";
 };
 

--- a/src/Https.re
+++ b/src/Https.re
@@ -1,9 +1,9 @@
 type https = [ `Https ];
 
 module HttpsServer = {
-  type kind = [ Tls.TlsSocket.kind | https ];
-  type subtype('a) = Net.Socket.subtype([> kind ] as 'a);
-  type supertype('a) = Net.Socket.subtype([< kind ] as 'a);
+  type kind = [ Tls.TlsServer.kind | https ];
+  type subtype('a) = Net.Server.subtype([> kind ] as 'a);
+  type supertype('a) = Net.Server.subtype([< kind ] as 'a);
   type t = subtype(kind);
   module Impl = {
     include Tls.TlsServer.Impl;

--- a/src/Net.re
+++ b/src/Net.re
@@ -164,7 +164,7 @@ module TcpSocket = {
   module Impl = {
     include Socket.Impl;
     [@bs.send] external connect: (
-      subtype([> kind ] as 'a),
+      subtype('a),
       ~port: int,
       ~host: string,
       unit => unit,
@@ -183,7 +183,7 @@ module IcpSocket = {
   module Impl = {
     include Socket.Impl;
     [@bs.send] external connect: (
-      subtype([> kind ] as 'a),
+      subtype('a),
       ~path: string,
       unit => unit,
     ) => subtype('a)

--- a/src/Net.re
+++ b/src/Net.re
@@ -25,20 +25,41 @@ module Socket = {
     type t = subtype(kind);
     type nonrec address = address;
 
+    module Events = {
+      [@bs.send] external onClose: (subtype('a), [@bs.as "close"] _, (. bool) => unit) => subtype('a) = "on";
+      [@bs.send] external onConnect: (subtype('a), [@bs.as "connect"] _, (. unit) => unit) => subtype('a) = "on";
+      [@bs.send] external onData: (subtype('a), [@bs.as "data"] _, (. Buffer.t) => unit) => subtype('a) = "on";
+      [@bs.send] external onDrain: (subtype('a), [@bs.as "drain"] _, (. unit) => unit) => subtype('a) = "on";
+      [@bs.send] external onEnd: (subtype('a), [@bs.as "end"] _, (. unit) => unit) => subtype('a) = "on";
+      [@bs.send] external onError: (subtype('a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => subtype('a) = "on";
+      [@bs.send] external onLookup: (subtype('a), [@bs.as "lookup"] _, (. unit) => unit) => subtype('a) = "on";
+      [@bs.send] external onReady: (subtype('a), [@bs.as "ready"] _, (. unit) => unit) => subtype('a) = "on";
+      [@bs.send] external onTimeout: (subtype('a), [@bs.as "timeout"] _, (unit) => unit) => subtype('a) = "on";
+
+      [@bs.send] external offClose: (subtype('a), [@bs.as "close"] _, (. bool) => unit) => subtype('a) = "off";
+      [@bs.send] external offConnect: (subtype('a), [@bs.as "connect"] _, (. unit) => unit) => subtype('a) = "off";
+      [@bs.send] external offData: (subtype('a), [@bs.as "data"] _, (. Buffer.t) => unit) => subtype('a) = "off";
+      [@bs.send] external offDrain: (subtype('a), [@bs.as "drain"] _, (. unit) => unit) => subtype('a) = "off";
+      [@bs.send] external offEnd: (subtype('a), [@bs.as "end"] _, (. unit) => unit) => subtype('a) = "off";
+      [@bs.send] external offError: (subtype('a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => subtype('a) = "off";
+      [@bs.send] external offLookup: (subtype('a), [@bs.as "lookup"] _, (. unit) => unit) => subtype('a) = "off";
+      [@bs.send] external offReady: (subtype('a), [@bs.as "ready"] _, (. unit) => unit) => subtype('a) = "off";
+      [@bs.send] external offTimeout: (subtype('a), [@bs.as "timeout"] _, (. unit) => unit) => subtype('a) = "off";
+
+      [@bs.send] external onCloseOnce: (subtype('a), [@bs.as "close"] _, (. bool) => unit) => subtype('a) = "once";
+      [@bs.send] external onConnectOnce: (subtype('a), [@bs.as "connect"] _, (. unit) => unit) => subtype('a) = "once";
+      [@bs.send] external onDataOnce: (subtype('a), [@bs.as "data"] _, (. Buffer.t) => unit) => subtype('a) = "once";
+      [@bs.send] external onDrainOnce: (subtype('a), [@bs.as "drain"] _, (. unit) => unit) => subtype('a) = "once";
+      [@bs.send] external onEndOnce: (subtype('a), [@bs.as "end"] _, (. unit) => unit) => subtype('a) = "once";
+      [@bs.send] external onErrorOnce: (subtype('a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => subtype('a) = "once";
+      [@bs.send] external onLookupOnce: (subtype('a), [@bs.as "lookup"] _, (. unit) => unit) => subtype('a) = "once";
+      [@bs.send] external onReadyOnce: (subtype('a), [@bs.as "ready"] _, (. unit) => unit) => subtype('a) = "once";
+      [@bs.send] external onTimeoutOnce: (subtype('a), [@bs.as "timeout"] _, (. unit) => unit) => subtype('a) = "once";
+    };
+
     module Impl = {
-
       include Stream.Base.Impl;
-
-      [@bs.send] external onClose: (subtype('a), [@bs.as "close"] _, bool => unit) => subtype('a) = "on";
-      [@bs.send] external onConnect: (subtype('a), [@bs.as "connect"] _, unit => unit) => subtype('a) = "on";
-      [@bs.send] external onData: (subtype('a), [@bs.as "data"] _, Buffer.t => unit) => subtype('a) = "on";
-      [@bs.send] external onDrain: (subtype('a), [@bs.as "drain"] _, unit => unit) => subtype('a) = "on";
-      [@bs.send] external onEnd: (subtype('a), [@bs.as "end"] _, unit => unit) => subtype('a) = "on";
-      [@bs.send] external onError: (subtype('a), [@bs.as "error"] _, Js.Exn.t => unit) => subtype('a) = "on";
-      [@bs.send] external onLookup: (subtype('a), [@bs.as "lookup"] _, unit => unit) => subtype('a) = "on";
-      [@bs.send] external onReady: (subtype('a), [@bs.as "ready"] _, unit => unit) => subtype('a) = "on";
-      [@bs.send] external onTimeout: (subtype('a), [@bs.as "timeout"] _, unit => unit) => subtype('a) = "on";
-
+      include Events;
       [@bs.send] external address: subtype('a) => address = "address";
       [@bs.get] external bufferSize: subtype('a) => int = "bufferSize";
       [@bs.get] external bytesRead: subtype('a) => int = "bytesRead";
@@ -71,7 +92,6 @@ module Socket = {
           unit => unit
         ) => subtype('a) = "connect";
     };
-
     include Impl;
 
     type makeOptions;
@@ -89,13 +109,18 @@ module Socket = {
 
   module Readable = {
     type kind = [ Stream.readable | Stream.socket ];
-    type subtype('a) = Stream.subtype(Buffer.t, [> kind ] as 'a);
-    type supertype('a) = Stream.subtype(Buffer.t, [< kind ] as 'a);
+    type subtype('a) = Stream.Readable.subtype(Buffer.t, [> kind ] as 'a);
+    type supertype('a) = Stream.Readable.subtype(Buffer.t, [< kind ] as 'a);
     type t = subtype(kind);
     type nonrec address = address;
+    module Events = {
+      include Stream.Readable.Events;
+      include Base.Events;
+    };
     module Impl = {
       include Stream.Readable.Impl;
       include Base.Impl;
+      include Events;
       [@bs.send] external setEncoding: (
           subtype('a),
           [@bs.string] [
@@ -117,13 +142,18 @@ module Socket = {
 
   module Writable = {
     type kind = [ Stream.writable | Stream.socket ];
-    type subtype('a) = Stream.subtype(Buffer.t, [> kind ] as 'a);
-    type supertype('a) = Stream.subtype(Buffer.t, [< kind ] as 'a);
+    type subtype('a) = Stream.Writable.subtype(Buffer.t, [> kind ] as 'a);
+    type supertype('a) = Stream.Writable.subtype(Buffer.t, [< kind ] as 'a);
     type t = subtype(kind);
     type nonrec address = address;
+    module Events = {
+      include Stream.Writable.Events;
+      include Base.Events;
+    };
     module Impl = {
       include Stream.Writable.Impl;
       include Base.Impl;
+      include Events;
       [@bs.send] external end_: (subtype('a)) => subtype('a) = "end";
       [@bs.send] external write: (subtype('a), Buffer.t, ~callback: [@bs.this] subtype('a) => unit) => bool = "write";
     };
@@ -133,15 +163,20 @@ module Socket = {
 
   module Duplex = {
     type kind = [ Stream.duplex | Stream.socket ];
-    type subtype('a) = Stream.subtype(Buffer.t, [> kind ] as 'a);
-    type supertype('a) = Stream.subtype(Buffer.t, [< kind ] as 'a);
+    type subtype('a) = Stream.Duplex.subtype(Buffer.t, [> kind ] as 'a);
+    type supertype('a) = Stream.Duplex.subtype(Buffer.t, [< kind ] as 'a);
     type t = subtype(kind);
     type nonrec address = address;
+    module Events = {
+      include Stream.Duplex.Events;
+      include Readable.Events;
+      include Writable.Events;
+    };
     module Impl = {
       include Stream.Duplex.Impl;
-      include Base.Impl;
       include Readable.Impl;
       include Writable.Impl;
+      include Events;
     };
     include Impl;
     [@bs.module "net"] [@bs.new] external make: unit => t = "Socket";
@@ -149,6 +184,7 @@ module Socket = {
 
   module Impl = {
     include Base.Impl;
+    include Base.Events;
   };
 
   include Impl;
@@ -158,8 +194,8 @@ module Socket = {
 
 module TcpSocket = {
   type nonrec kind = [ Socket.Duplex.kind | tcp ];
-  type subtype('a) = Socket.subtype([> kind ] as 'a);
-  type supertype('a) = Socket.subtype([< kind ] as 'a);
+  type subtype('a) = Socket.Duplex.subtype([> kind ] as 'a);
+  type supertype('a) = Socket.Duplex.subtype([< kind ] as 'a);
   type t = subtype(kind);
   module Impl = {
     include Socket.Impl;
@@ -177,8 +213,8 @@ module TcpSocket = {
 
 module IcpSocket = {
   type kind = [ Socket.Duplex.kind | icp ];
-  type subtype('a) = Socket.subtype([> kind ] as 'a);
-  type supertype('a) = Socket.subtype([< kind ] as 'a);
+  type subtype('a) = Socket.Duplex.subtype([> kind ] as 'a);
+  type supertype('a) = Socket.Duplex.subtype([< kind ] as 'a);
   type t = subtype(kind);
   module Impl = {
     include Socket.Impl;
@@ -201,9 +237,14 @@ module Server = {
   type subtype('a) constraint 'a = [> kind ];
   type supertype('a) constraint 'a = [< kind ];
   type t = subtype(kind);
-
+  module Events = (T: { type t; }) => {
+    [@bs.send] external onClose: (T.t, [@bs.as "close"] _, (. unit) => unit) => T.t = "on";
+    [@bs.send] external onError: (T.t, [@bs.as "error"] _, (. unit) => unit) => T.t = "on";
+    [@bs.send] external onConnection: (T.t, [@bs.as "connection"] _, (. Socket.t) => unit) => T.t = "on";
+    [@bs.send] external onListening: (T.t, [@bs.as "listening"] _, (. unit) => unit) => T.t = "on";
+  };
   module Impl = (T: { type t; }) => {
-
+    include Events(T);
     [@bs.send] external close: (T.t, ~callback: Js.nullable(Js.Exn.t) => unit=?, unit) => T.t = "close";
     [@bs.send] external onClose: (T.t, [@bs.as "close"] _, unit => unit) => T.t = "on";
     [@bs.send] external onError: (T.t, [@bs.as "error"] _, unit => unit) => T.t = "on";
@@ -214,7 +255,6 @@ module Server = {
     [@bs.send] external ref: (T.t) => T.t = "ref";
     [@bs.send] external unref: (T.t) => T.t = "unref";
     [@bs.get] external listening: (T.t) => bool = "listening"
-
   };
 
   include Impl({ type nonrec t = t; });
@@ -226,20 +266,21 @@ module TcpServer = {
   type subtype('a) = Server.subtype([> kind ] as 'a);
   type supertype('a) = Server.subtype([< kind ] as 'a);
   type t = subtype(kind);
-
+  module Events = (T: { type t; }) => {
+    [@bs.send] external onClose: (T.t, [@bs.as "close"] _, (. unit) => unit) => T.t = "on";
+    [@bs.send] external onError: (T.t, [@bs.as "error"] _, (. unit) => unit) => T.t = "on";
+    [@bs.send] external onConnection: (T.t, [@bs.as "connection"] _, (. TcpSocket.t) => unit) => T.t = "on";
+    [@bs.send] external onListening: (T.t, [@bs.as "listening"] _, (. unit) => unit) => T.t = "on";
+  };
   module Impl = (T: { type t; }) => {
-
+    include Events(T);
     [@bs.send] external close: (T.t, ~callback: Js.nullable(Js.Exn.t) => unit=?, unit) => T.t = "close";
-    [@bs.send] external onClose: (T.t, [@bs.as "close"] _, unit => unit) => T.t = "on";
-    [@bs.send] external onError: (T.t, [@bs.as "error"] _, unit => unit) => T.t = "on";
-    [@bs.send] external onConnection: (T.t, [@bs.as "connection"] _, unit => unit) => T.t = "on";
     [@bs.send] external getConnections: (T.t, (Js.nullable(Js.Exn.t), int) => unit) => T.t = "getConnections";
     [@bs.set] external setMaxConnections: (T.t, int) => unit = "maxConnections";
     [@bs.get] external maxConnections: (T.t) => int = "maxConnections";
     [@bs.send] external ref: (T.t) => T.t = "ref";
     [@bs.send] external unref: (T.t) => T.t = "unref";
     [@bs.get] external listening: (T.t) => bool = "listening"
-
   };
 
   include Impl({ type nonrec t = t; });
@@ -264,20 +305,21 @@ module IcpServer = {
   type subtype('a) = Server.subtype([> kind ] as 'a);
   type supertype('a) = Server.subtype([< kind ] as 'a);
   type t = subtype(kind);
-
+  module Events = (T: { type t; }) => {
+    [@bs.send] external onClose: (T.t, [@bs.as "close"] _, (. unit) => unit) => T.t = "on";
+    [@bs.send] external onError: (T.t, [@bs.as "error"] _, (. unit) => unit) => T.t = "on";
+    [@bs.send] external onConnection: (T.t, [@bs.as "connection"] _, (. IcpSocket.t) => unit) => T.t = "on";
+    [@bs.send] external onListening: (T.t, [@bs.as "listening"] _, (. unit) => unit) => T.t = "on";
+  };
   module Impl = (T: { type t; }) => {
-
+    include Events(T);
     [@bs.send] external close: (T.t, ~callback: Js.nullable(Js.Exn.t) => unit=?, unit) => T.t = "close";
-    [@bs.send] external onClose: (T.t, [@bs.as "close"] _, unit => unit) => T.t = "on";
-    [@bs.send] external onError: (T.t, [@bs.as "error"] _, unit => unit) => T.t = "on";
-    [@bs.send] external onConnection: (T.t, [@bs.as "connection"] _, unit => unit) => T.t = "on";
     [@bs.send] external getConnections: (T.t, (Js.nullable(Js.Exn.t), int) => unit) => T.t = "getConnections";
     [@bs.set] external setMaxConnections: (T.t, int) => unit = "maxConnections";
     [@bs.get] external maxConnections: (T.t) => int = "maxConnections";
     [@bs.send] external ref: (T.t) => T.t = "ref";
     [@bs.send] external unref: (T.t) => T.t = "unref";
     [@bs.get] external listening: (T.t) => bool = "listening"
-
   };
 
   include Impl({ type nonrec t = t; });

--- a/src/Net.re
+++ b/src/Net.re
@@ -242,13 +242,18 @@ module Server = {
     [@bs.send] external onError: (subtype('a), [@bs.as "error"] _, (. unit) => unit) => subtype('a) = "on";
     [@bs.send] external onConnection: (subtype('a), [@bs.as "connection"] _, (. Socket.t) => unit) => subtype('a) = "on";
     [@bs.send] external onListening: (subtype('a), [@bs.as "listening"] _, (. unit) => unit) => subtype('a) = "on";
+    [@bs.send] external offClose: (subtype('a), [@bs.as "close"] _, (. unit) => unit) => subtype('a) = "off";
+    [@bs.send] external offError: (subtype('a), [@bs.as "error"] _, (. unit) => unit) => subtype('a) = "off";
+    [@bs.send] external offConnection: (subtype('a), [@bs.as "connection"] _, (. Socket.t) => unit) => subtype('a) = "off";
+    [@bs.send] external offListening: (subtype('a), [@bs.as "listening"] _, (. unit) => unit) => subtype('a) = "off";
+    [@bs.send] external onCloseOnce: (subtype('a), [@bs.as "close"] _, (. unit) => unit) => subtype('a) = "once";
+    [@bs.send] external onErrorOnce: (subtype('a), [@bs.as "error"] _, (. unit) => unit) => subtype('a) = "once";
+    [@bs.send] external onConnectionOnce: (subtype('a), [@bs.as "connection"] _, (. Socket.t) => unit) => subtype('a) = "once";
+    [@bs.send] external onListeningOnce: (subtype('a), [@bs.as "listening"] _, (. unit) => unit) => subtype('a) = "once";
   };
   module Impl = {
     include Events;
     [@bs.send] external close: (subtype('a), ~callback: Js.nullable(Js.Exn.t) => unit=?, unit) => subtype('a) = "close";
-    [@bs.send] external onClose: (subtype('a), [@bs.as "close"] _, unit => unit) => subtype('a) = "on";
-    [@bs.send] external onError: (subtype('a), [@bs.as "error"] _, unit => unit) => subtype('a) = "on";
-    [@bs.send] external onConnection: (subtype('a), [@bs.as "connection"] _, unit => unit) => subtype('a) = "on";
     [@bs.send] external getConnections: (subtype('a), (Js.nullable(Js.Exn.t), int) => unit) => subtype('a) = "getConnections";
     [@bs.set] external setMaxConnections: (subtype('a), int) => unit = "maxConnections";
     [@bs.get] external maxConnections: (subtype('a)) => int = "maxConnections";
@@ -271,6 +276,14 @@ module TcpServer = {
     [@bs.send] external onError: (subtype('a), [@bs.as "error"] _, (. unit) => unit) => subtype('a) = "on";
     [@bs.send] external onConnection: (subtype('a), [@bs.as "connection"] _, (. TcpSocket.t) => unit) => subtype('a) = "on";
     [@bs.send] external onListening: (subtype('a), [@bs.as "listening"] _, (. unit) => unit) => subtype('a) = "on";
+    [@bs.send] external offClose: (subtype('a), [@bs.as "close"] _, (. unit) => unit) => subtype('a) = "off";
+    [@bs.send] external offError: (subtype('a), [@bs.as "error"] _, (. unit) => unit) => subtype('a) = "off";
+    [@bs.send] external offConnection: (subtype('a), [@bs.as "connection"] _, (. TcpSocket.t) => unit) => subtype('a) = "off";
+    [@bs.send] external offListening: (subtype('a), [@bs.as "listening"] _, (. unit) => unit) => subtype('a) = "off";
+    [@bs.send] external onCloseOnce: (subtype('a), [@bs.as "close"] _, (. unit) => unit) => subtype('a) = "once";
+    [@bs.send] external onErrorOnce: (subtype('a), [@bs.as "error"] _, (. unit) => unit) => subtype('a) = "once";
+    [@bs.send] external onConnectionOnce: (subtype('a), [@bs.as "connection"] _, (. TcpSocket.t) => unit) => subtype('a) = "once";
+    [@bs.send] external onListeningOnce: (subtype('a), [@bs.as "listening"] _, (. unit) => unit) => subtype('a) = "once";
   };
   module Impl = {
     include Events;
@@ -282,9 +295,7 @@ module TcpServer = {
     [@bs.send] external unref: (subtype('a)) => subtype('a) = "unref";
     [@bs.get] external listening: (subtype('a)) => bool = "listening"
   };
-
   include Impl;
-
   type listenOptions;
   [@bs.obj] external listenOptions: (
     ~port: int=?,
@@ -305,14 +316,22 @@ module IcpServer = {
   type subtype('a) = Server.subtype([> kind ] as 'a);
   type supertype('a) = Server.subtype([< kind ] as 'a);
   type t = subtype(kind);
-  module Events = (T: { type t; }) => {
+  module Events = {
     [@bs.send] external onClose: (subtype('a), [@bs.as "close"] _, (. unit) => unit) => subtype('a) = "on";
     [@bs.send] external onError: (subtype('a), [@bs.as "error"] _, (. unit) => unit) => subtype('a) = "on";
     [@bs.send] external onConnection: (subtype('a), [@bs.as "connection"] _, (. IcpSocket.t) => unit) => subtype('a) = "on";
     [@bs.send] external onListening: (subtype('a), [@bs.as "listening"] _, (. unit) => unit) => subtype('a) = "on";
+    [@bs.send] external offClose: (subtype('a), [@bs.as "close"] _, (. unit) => unit) => subtype('a) = "off";
+    [@bs.send] external offError: (subtype('a), [@bs.as "error"] _, (. unit) => unit) => subtype('a) = "off";
+    [@bs.send] external offConnection: (subtype('a), [@bs.as "connection"] _, (. IcpSocket.t) => unit) => subtype('a) = "off";
+    [@bs.send] external offListening: (subtype('a), [@bs.as "listening"] _, (. unit) => unit) => subtype('a) = "off";
+    [@bs.send] external onCloseOnce: (subtype('a), [@bs.as "close"] _, (. unit) => unit) => subtype('a) = "once";
+    [@bs.send] external onErrorOnce: (subtype('a), [@bs.as "error"] _, (. unit) => unit) => subtype('a) = "once";
+    [@bs.send] external onConnectionOnce: (subtype('a), [@bs.as "connection"] _, (. IcpSocket.t) => unit) => subtype('a) = "once";
+    [@bs.send] external onListeningOnce: (subtype('a), [@bs.as "listening"] _, (. unit) => unit) => subtype('a) = "once";
   };
-  module Impl = (T: { type t; }) => {
-    include Events(T);
+  module Impl = {
+    include Events;
     [@bs.send] external close: (subtype('a), ~callback: Js.nullable(Js.Exn.t) => unit=?, unit) => subtype('a) = "close";
     [@bs.send] external getConnections: (subtype('a), (Js.nullable(Js.Exn.t), int) => unit) => subtype('a) = "getConnections";
     [@bs.set] external setMaxConnections: (subtype('a), int) => unit = "maxConnections";
@@ -321,9 +340,7 @@ module IcpServer = {
     [@bs.send] external unref: (subtype('a)) => subtype('a) = "unref";
     [@bs.get] external listening: (subtype('a)) => bool = "listening"
   };
-
-  include Impl({ type nonrec t = t; });
-
+  include Impl;
   type listenOptions;
   [@bs.obj] external listenOptions: (
     ~path: string=?,
@@ -334,8 +351,8 @@ module IcpServer = {
     ~writableAll: bool=?,
     unit
   ) => listenOptions = "";
-  [@bs.send] external listen: (~path: string, ~callback: unit => unit=?, unit) => t = "listen";
-  [@bs.send] external listenWith: (~options: listenOptions, ~callback: unit => unit=?, unit) => t = "listen";
+  [@bs.send] external listen: (t, ~path: string, ~callback: unit => unit=?, unit) => t = "listen";
+  [@bs.send] external listenWith: (t, ~options: listenOptions, ~callback: unit => unit=?, unit) => t = "listen";
 
 };
 

--- a/src/Net.re
+++ b/src/Net.re
@@ -237,27 +237,27 @@ module Server = {
   type subtype('a) constraint 'a = [> kind ];
   type supertype('a) constraint 'a = [< kind ];
   type t = subtype(kind);
-  module Events = (T: { type t; }) => {
-    [@bs.send] external onClose: (T.t, [@bs.as "close"] _, (. unit) => unit) => T.t = "on";
-    [@bs.send] external onError: (T.t, [@bs.as "error"] _, (. unit) => unit) => T.t = "on";
-    [@bs.send] external onConnection: (T.t, [@bs.as "connection"] _, (. Socket.t) => unit) => T.t = "on";
-    [@bs.send] external onListening: (T.t, [@bs.as "listening"] _, (. unit) => unit) => T.t = "on";
+  module Events = {
+    [@bs.send] external onClose: (subtype('a), [@bs.as "close"] _, (. unit) => unit) => subtype('a) = "on";
+    [@bs.send] external onError: (subtype('a), [@bs.as "error"] _, (. unit) => unit) => subtype('a) = "on";
+    [@bs.send] external onConnection: (subtype('a), [@bs.as "connection"] _, (. Socket.t) => unit) => subtype('a) = "on";
+    [@bs.send] external onListening: (subtype('a), [@bs.as "listening"] _, (. unit) => unit) => subtype('a) = "on";
   };
-  module Impl = (T: { type t; }) => {
-    include Events(T);
-    [@bs.send] external close: (T.t, ~callback: Js.nullable(Js.Exn.t) => unit=?, unit) => T.t = "close";
-    [@bs.send] external onClose: (T.t, [@bs.as "close"] _, unit => unit) => T.t = "on";
-    [@bs.send] external onError: (T.t, [@bs.as "error"] _, unit => unit) => T.t = "on";
-    [@bs.send] external onConnection: (T.t, [@bs.as "connection"] _, unit => unit) => T.t = "on";
-    [@bs.send] external getConnections: (T.t, (Js.nullable(Js.Exn.t), int) => unit) => T.t = "getConnections";
-    [@bs.set] external setMaxConnections: (T.t, int) => unit = "maxConnections";
-    [@bs.get] external maxConnections: (T.t) => int = "maxConnections";
-    [@bs.send] external ref: (T.t) => T.t = "ref";
-    [@bs.send] external unref: (T.t) => T.t = "unref";
-    [@bs.get] external listening: (T.t) => bool = "listening"
+  module Impl = {
+    include Events;
+    [@bs.send] external close: (subtype('a), ~callback: Js.nullable(Js.Exn.t) => unit=?, unit) => subtype('a) = "close";
+    [@bs.send] external onClose: (subtype('a), [@bs.as "close"] _, unit => unit) => subtype('a) = "on";
+    [@bs.send] external onError: (subtype('a), [@bs.as "error"] _, unit => unit) => subtype('a) = "on";
+    [@bs.send] external onConnection: (subtype('a), [@bs.as "connection"] _, unit => unit) => subtype('a) = "on";
+    [@bs.send] external getConnections: (subtype('a), (Js.nullable(Js.Exn.t), int) => unit) => subtype('a) = "getConnections";
+    [@bs.set] external setMaxConnections: (subtype('a), int) => unit = "maxConnections";
+    [@bs.get] external maxConnections: (subtype('a)) => int = "maxConnections";
+    [@bs.send] external ref: (subtype('a)) => subtype('a) = "ref";
+    [@bs.send] external unref: (subtype('a)) => subtype('a) = "unref";
+    [@bs.get] external listening: (subtype('a)) => bool = "listening"
   };
 
-  include Impl({ type nonrec t = t; });
+  include Impl;
 
 };
 
@@ -266,24 +266,24 @@ module TcpServer = {
   type subtype('a) = Server.subtype([> kind ] as 'a);
   type supertype('a) = Server.subtype([< kind ] as 'a);
   type t = subtype(kind);
-  module Events = (T: { type t; }) => {
-    [@bs.send] external onClose: (T.t, [@bs.as "close"] _, (. unit) => unit) => T.t = "on";
-    [@bs.send] external onError: (T.t, [@bs.as "error"] _, (. unit) => unit) => T.t = "on";
-    [@bs.send] external onConnection: (T.t, [@bs.as "connection"] _, (. TcpSocket.t) => unit) => T.t = "on";
-    [@bs.send] external onListening: (T.t, [@bs.as "listening"] _, (. unit) => unit) => T.t = "on";
+  module Events = {
+    [@bs.send] external onClose: (subtype('a), [@bs.as "close"] _, (. unit) => unit) => subtype('a) = "on";
+    [@bs.send] external onError: (subtype('a), [@bs.as "error"] _, (. unit) => unit) => subtype('a) = "on";
+    [@bs.send] external onConnection: (subtype('a), [@bs.as "connection"] _, (. TcpSocket.t) => unit) => subtype('a) = "on";
+    [@bs.send] external onListening: (subtype('a), [@bs.as "listening"] _, (. unit) => unit) => subtype('a) = "on";
   };
-  module Impl = (T: { type t; }) => {
-    include Events(T);
-    [@bs.send] external close: (T.t, ~callback: Js.nullable(Js.Exn.t) => unit=?, unit) => T.t = "close";
-    [@bs.send] external getConnections: (T.t, (Js.nullable(Js.Exn.t), int) => unit) => T.t = "getConnections";
-    [@bs.set] external setMaxConnections: (T.t, int) => unit = "maxConnections";
-    [@bs.get] external maxConnections: (T.t) => int = "maxConnections";
-    [@bs.send] external ref: (T.t) => T.t = "ref";
-    [@bs.send] external unref: (T.t) => T.t = "unref";
-    [@bs.get] external listening: (T.t) => bool = "listening"
+  module Impl = {
+    include Events;
+    [@bs.send] external close: (subtype('a), ~callback: Js.nullable(Js.Exn.t) => unit=?, unit) => subtype('a) = "close";
+    [@bs.send] external getConnections: (subtype('a), (Js.nullable(Js.Exn.t), int) => unit) => subtype('a) = "getConnections";
+    [@bs.set] external setMaxConnections: (subtype('a), int) => unit = "maxConnections";
+    [@bs.get] external maxConnections: (subtype('a)) => int = "maxConnections";
+    [@bs.send] external ref: (subtype('a)) => subtype('a) = "ref";
+    [@bs.send] external unref: (subtype('a)) => subtype('a) = "unref";
+    [@bs.get] external listening: (subtype('a)) => bool = "listening"
   };
 
-  include Impl({ type nonrec t = t; });
+  include Impl;
 
   type listenOptions;
   [@bs.obj] external listenOptions: (
@@ -306,20 +306,20 @@ module IcpServer = {
   type supertype('a) = Server.subtype([< kind ] as 'a);
   type t = subtype(kind);
   module Events = (T: { type t; }) => {
-    [@bs.send] external onClose: (T.t, [@bs.as "close"] _, (. unit) => unit) => T.t = "on";
-    [@bs.send] external onError: (T.t, [@bs.as "error"] _, (. unit) => unit) => T.t = "on";
-    [@bs.send] external onConnection: (T.t, [@bs.as "connection"] _, (. IcpSocket.t) => unit) => T.t = "on";
-    [@bs.send] external onListening: (T.t, [@bs.as "listening"] _, (. unit) => unit) => T.t = "on";
+    [@bs.send] external onClose: (subtype('a), [@bs.as "close"] _, (. unit) => unit) => subtype('a) = "on";
+    [@bs.send] external onError: (subtype('a), [@bs.as "error"] _, (. unit) => unit) => subtype('a) = "on";
+    [@bs.send] external onConnection: (subtype('a), [@bs.as "connection"] _, (. IcpSocket.t) => unit) => subtype('a) = "on";
+    [@bs.send] external onListening: (subtype('a), [@bs.as "listening"] _, (. unit) => unit) => subtype('a) = "on";
   };
   module Impl = (T: { type t; }) => {
     include Events(T);
-    [@bs.send] external close: (T.t, ~callback: Js.nullable(Js.Exn.t) => unit=?, unit) => T.t = "close";
-    [@bs.send] external getConnections: (T.t, (Js.nullable(Js.Exn.t), int) => unit) => T.t = "getConnections";
-    [@bs.set] external setMaxConnections: (T.t, int) => unit = "maxConnections";
-    [@bs.get] external maxConnections: (T.t) => int = "maxConnections";
-    [@bs.send] external ref: (T.t) => T.t = "ref";
-    [@bs.send] external unref: (T.t) => T.t = "unref";
-    [@bs.get] external listening: (T.t) => bool = "listening"
+    [@bs.send] external close: (subtype('a), ~callback: Js.nullable(Js.Exn.t) => unit=?, unit) => subtype('a) = "close";
+    [@bs.send] external getConnections: (subtype('a), (Js.nullable(Js.Exn.t), int) => unit) => subtype('a) = "getConnections";
+    [@bs.set] external setMaxConnections: (subtype('a), int) => unit = "maxConnections";
+    [@bs.get] external maxConnections: (subtype('a)) => int = "maxConnections";
+    [@bs.send] external ref: (subtype('a)) => subtype('a) = "ref";
+    [@bs.send] external unref: (subtype('a)) => subtype('a) = "unref";
+    [@bs.get] external listening: (subtype('a)) => bool = "listening"
   };
 
   include Impl({ type nonrec t = t; });

--- a/src/Net.re
+++ b/src/Net.re
@@ -13,10 +13,15 @@ module Socket = {
   type writable = [ Stream.writable | Stream.socket ];
   type duplex = [ Stream.duplex | Stream.socket ];
 
+  type kind = [ Stream.socket ];
+  type subtype('a) = Stream.subtype(Buffer.t, [> kind ] as 'a);
+  type supertype('a) = Stream.subtype(Buffer.t, [< kind ] as 'a);
+  type t = subtype(kind);
+
   module Base = {
-    type kind = [ Stream.socket ];
-    type subtype('a) = Stream.subtype(Buffer.t, [> kind ] as 'a);
-    type supertype('a) = Stream.subtype(Buffer.t, [< kind ] as 'a);
+    type nonrec kind = kind;
+    type nonrec subtype('a) = subtype('a);
+    type nonrec supertype('a) = supertype('a);
     type t = subtype(kind);
     type nonrec address = address;
 
@@ -141,11 +146,6 @@ module Socket = {
     include Impl;
     [@bs.module "net"] [@bs.new] external make: unit => t = "Socket";
   };
-
-  type kind = [ Stream.socket ];
-  type subtype('a) = Stream.subtype(Buffer.t, [> kind ] as 'a);
-  type supertype('a) = Stream.subtype(Buffer.t, [< kind ] as 'a);
-  type t = subtype(kind);
 
   module Impl = {
     include Base.Impl;

--- a/src/Net.re
+++ b/src/Net.re
@@ -197,8 +197,12 @@ module TcpSocket = {
   type subtype('a) = Socket.Duplex.subtype([> kind ] as 'a);
   type supertype('a) = Socket.Duplex.subtype([< kind ] as 'a);
   type t = subtype(kind);
+  module Events = {
+    include Socket.Duplex.Events;
+  };
   module Impl = {
-    include Socket.Impl;
+    include Socket.Duplex.Impl;
+    include Events;
     [@bs.send] external connect: (
       subtype('a),
       ~port: int,
@@ -216,8 +220,11 @@ module IcpSocket = {
   type subtype('a) = Socket.Duplex.subtype([> kind ] as 'a);
   type supertype('a) = Socket.Duplex.subtype([< kind ] as 'a);
   type t = subtype(kind);
+  module Events = {
+    include Socket.Duplex.Events;
+  };
   module Impl = {
-    include Socket.Impl;
+    include Socket.Duplex.Impl;
     [@bs.send] external connect: (
       subtype('a),
       ~path: string,

--- a/src/Process.re
+++ b/src/Process.re
@@ -65,25 +65,6 @@ module Events = {
   external onUnhandledRejectionOnce:
     ([@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => unit =
     "once";
-
-  [@bs.module "process"] external emitBeforeExit: ([@bs.as "beforeExit"] _, int) => bool = "emit";
-  [@bs.module "process"] external emitDisconnect: ([@bs.as "disconnect"] _) => bool = "emit";
-  [@bs.module "process"] external emitExit: ([@bs.as "exit"] _, int) => bool = "emit";
-  [@bs.module "process"]
-  external emitMultipleResolves:
-    ([@bs.as "multipleResolves"] _, [@bs.string] [ | `resolve | `reject], Js.Promise.t('a), 'a) =>
-    bool =
-    "emit";
-  [@bs.module "process"]
-  external emitRejectionHandled: ([@bs.as "rejectionHandled"] _, Js.Promise.t('a)) => bool =
-    "emit";
-  [@bs.module "process"]
-  external emitUncaughtException: ([@bs.as "uncaughtException"] _, Js.Exn.t, string) => bool =
-    "emit";
-  [@bs.module "process"]
-  external emitUnhandledRejection:
-    ([@bs.as "unhandledRejection"] _, Js.Exn.t, Js.Promise.t('a)) => bool =
-    "emit";
 };
 include Events;
 type warning = {

--- a/src/Process.re
+++ b/src/Process.re
@@ -29,7 +29,7 @@ type warning = {
   message: string,
   stack: string,
 };
-[@bs.module "process"] external onWarning: ([@bs.as "warning"] _, warning => unit) => unit = "on";
+[@bs.module "process"] external onWarning: ([@bs.as "warning"] _, (. warning) => unit) => unit = "on";
 [@bs.module "process"] external abort: unit => unit = "abort";
 [@bs.module "process"] external argv: array(string) = "argv";
 [@bs.module "process"] external argv0: string = "argv0";

--- a/src/Process.re
+++ b/src/Process.re
@@ -1,70 +1,27 @@
 module Events = {
-  [@bs.module "process"]
-  external onBeforeExit: ([@bs.as "beforeExit"] _, (. int) => unit) => unit = "on";
-  [@bs.module "process"]
-  external onDisconnect: ([@bs.as "disconnect"] _, (. unit) => unit) => unit = "on";
+  [@bs.module "process"] external onBeforeExit: ([@bs.as "beforeExit"] _, (. int) => unit) => unit = "on";
+  [@bs.module "process"] external onDisconnect: ([@bs.as "disconnect"] _, (. unit) => unit) => unit = "on";
   [@bs.module "process"] external onExit: ([@bs.as "exit"] _, (. int) => unit) => unit = "on";
-  [@bs.module "process"]
-  external onMultipleResolves:
-    ([@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => unit =
-    "on";
-  [@bs.module "process"]
-  external onRejectionHandled:
-    ([@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => unit =
-    "on";
-  [@bs.module "process"]
-  external onUncaughtException:
-    ([@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => unit =
-    "on";
-  [@bs.module "process"]
-  external onUnhandledRejection:
-    ([@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => unit =
-    "on";
+  [@bs.module "process"] external onMultipleResolves: ([@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => unit = "on";
+  [@bs.module "process"] external onRejectionHandled: ([@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => unit = "on";
+  [@bs.module "process"] external onUncaughtException: ([@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => unit = "on";
+  [@bs.module "process"] external onUnhandledRejection: ([@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => unit = "on";
 
-  [@bs.module "process"]
-  external offBeforeExit: ([@bs.as "beforeExit"] _, (. int) => unit) => unit = "off";
-  [@bs.module "process"]
-  external offDisconnect: ([@bs.as "disconnect"] _, (. unit) => unit) => unit = "off";
+  [@bs.module "process"] external offBeforeExit: ([@bs.as "beforeExit"] _, (. int) => unit) => unit = "off";
+  [@bs.module "process"] external offDisconnect: ([@bs.as "disconnect"] _, (. unit) => unit) => unit = "off";
   [@bs.module "process"] external offExit: ([@bs.as "exit"] _, (. int) => unit) => unit = "off";
-  [@bs.module "process"]
-  external offMultipleResolves:
-    ([@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => unit =
-    "off";
-  [@bs.module "process"]
-  external offRejectionHandled:
-    ([@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => unit =
-    "off";
-  [@bs.module "process"]
-  external offUncaughtException:
-    ([@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => unit =
-    "off";
-  [@bs.module "process"]
-  external offUnhandledRejection:
-    ([@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => unit =
-    "off";
+  [@bs.module "process"] external offMultipleResolves: ([@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => unit = "off";
+  [@bs.module "process"] external offRejectionHandled: ([@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => unit = "off";
+  [@bs.module "process"] external offUncaughtException: ([@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => unit = "off";
+  [@bs.module "process"] external offUnhandledRejection: ([@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => unit = "off";
 
-  [@bs.module "process"]
-  external onBeforeExitOnce: ([@bs.as "beforeExit"] _, (. int) => unit) => unit = "once";
-  [@bs.module "process"]
-  external onDisconnectOnce: ([@bs.as "disconnect"] _, (. unit) => unit) => unit = "once";
-  [@bs.module "process"]
-  external onExitOnce: ([@bs.as "exit"] _, (. int) => unit) => unit = "once";
-  [@bs.module "process"]
-  external onMultipleResolvesOnce:
-    ([@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => unit =
-    "once";
-  [@bs.module "process"]
-  external onRejectionHandledOnce:
-    ([@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => unit =
-    "once";
-  [@bs.module "process"]
-  external onUncaughtExceptionOnce:
-    ([@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => unit =
-    "once";
-  [@bs.module "process"]
-  external onUnhandledRejectionOnce:
-    ([@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => unit =
-    "once";
+  [@bs.module "process"] external onBeforeExitOnce: ([@bs.as "beforeExit"] _, (. int) => unit) => unit = "once";
+  [@bs.module "process"] external onDisconnectOnce: ([@bs.as "disconnect"] _, (. unit) => unit) => unit = "once";
+  [@bs.module "process"] external onExitOnce: ([@bs.as "exit"] _, (. int) => unit) => unit = "once";
+  [@bs.module "process"] external onMultipleResolvesOnce: ([@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => unit = "once";
+  [@bs.module "process"] external onRejectionHandledOnce: ([@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => unit = "once";
+  [@bs.module "process"] external onUncaughtExceptionOnce: ([@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => unit = "once";
+  [@bs.module "process"] external onUnhandledRejectionOnce: ([@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => unit = "once";
 };
 include Events;
 type warning = {
@@ -88,12 +45,9 @@ type warning = {
 [@bs.module "process"] external nextTick: (unit => unit) => unit = "nextTick";
 [@bs.module "process"] external hrtime: unit => (int, int) = "hrtime";
 [@bs.module "process"] [@bs.scope "hrtime"] external hrtimeBigInt: unit => BigInt.t = "bigint";
-[@bs.module "process"]
-external stderr: Stream.subtype(Buffer.t, [< Net.Socket.kind | Stream.writable]) = "stderr";
-[@bs.module "process"]
-external stdin: Stream.subtype(Buffer.t, [< Net.Socket.kind | Stream.readable]) = "stdin";
-[@bs.module "process"]
-external stdout: Stream.subtype(Buffer.t, [< Net.Socket.kind | Stream.writable]) = "stdout";
+[@bs.module "process"] external stderr: Stream.Writable.subtype(Buffer.t, [< Stream.socket | Stream.writable]) = "stderr";
+[@bs.module "process"] external stdin: Stream.Readable.subtype(Buffer.t, [< Stream.socket | Stream.readable]) = "stdin";
+[@bs.module "process"] external stdout: Stream.Writable.subtype(Buffer.t, [< Stream.socket | Stream.writable]) = "stdout";
 [@bs.module "process"] external pid: int = "pid";
 [@bs.module "process"] external platform: string = "platform";
 [@bs.module "process"] external ppid: int = "ppid";

--- a/src/Process.re
+++ b/src/Process.re
@@ -1,54 +1,122 @@
-[@bs.module "process"] [@bs.val]
-external onBeforeExit: ([@bs.as "beforeExit"] _, int => unit) => unit = "on";
-[@bs.module "process"] [@bs.val]
-external onDisconnect: ([@bs.as "disconnect"] _, unit => unit) => unit = "on";
-[@bs.module "process"] [@bs.val]
-external onExit: ([@bs.as "exit"] _, int => unit) => unit = "on";
-[@bs.module "process"] [@bs.val]
-external onUncaughtException:
-  ([@bs.as "uncaughtException"] _, (Js.Exn.t, string) => unit) => unit =
-  "on";
-[@bs.module "process"] [@bs.val]
-external onUnhandledRejection:
-  ([@bs.as "unhandledRejection"] _, (Js.Exn.t, Js.Promise.t('a)) => unit) =>
-  unit =
-  "on";
+module Events = {
+  [@bs.module "process"]
+  external onBeforeExit: ([@bs.as "beforeExit"] _, (. int) => unit) => unit = "on";
+  [@bs.module "process"]
+  external onDisconnect: ([@bs.as "disconnect"] _, (. unit) => unit) => unit = "on";
+  [@bs.module "process"] external onExit: ([@bs.as "exit"] _, (. int) => unit) => unit = "on";
+  [@bs.module "process"]
+  external onMultipleResolves:
+    ([@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => unit =
+    "on";
+  [@bs.module "process"]
+  external onRejectionHandled:
+    ([@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => unit =
+    "on";
+  [@bs.module "process"]
+  external onUncaughtException:
+    ([@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => unit =
+    "on";
+  [@bs.module "process"]
+  external onUnhandledRejection:
+    ([@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => unit =
+    "on";
+
+  [@bs.module "process"]
+  external offBeforeExit: ([@bs.as "beforeExit"] _, (. int) => unit) => unit = "off";
+  [@bs.module "process"]
+  external offDisconnect: ([@bs.as "disconnect"] _, (. unit) => unit) => unit = "off";
+  [@bs.module "process"] external offExit: ([@bs.as "exit"] _, (. int) => unit) => unit = "off";
+  [@bs.module "process"]
+  external offMultipleResolves:
+    ([@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => unit =
+    "off";
+  [@bs.module "process"]
+  external offRejectionHandled:
+    ([@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => unit =
+    "off";
+  [@bs.module "process"]
+  external offUncaughtException:
+    ([@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => unit =
+    "off";
+  [@bs.module "process"]
+  external offUnhandledRejection:
+    ([@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => unit =
+    "off";
+
+  [@bs.module "process"]
+  external onBeforeExitOnce: ([@bs.as "beforeExit"] _, (. int) => unit) => unit = "once";
+  [@bs.module "process"]
+  external onDisconnectOnce: ([@bs.as "disconnect"] _, (. unit) => unit) => unit = "once";
+  [@bs.module "process"]
+  external onExitOnce: ([@bs.as "exit"] _, (. int) => unit) => unit = "once";
+  [@bs.module "process"]
+  external onMultipleResolvesOnce:
+    ([@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => unit =
+    "once";
+  [@bs.module "process"]
+  external onRejectionHandledOnce:
+    ([@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => unit =
+    "once";
+  [@bs.module "process"]
+  external onUncaughtExceptionOnce:
+    ([@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => unit =
+    "once";
+  [@bs.module "process"]
+  external onUnhandledRejectionOnce:
+    ([@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => unit =
+    "once";
+
+  [@bs.module "process"] external emitBeforeExit: ([@bs.as "beforeExit"] _, int) => bool = "emit";
+  [@bs.module "process"] external emitDisconnect: ([@bs.as "disconnect"] _) => bool = "emit";
+  [@bs.module "process"] external emitExit: ([@bs.as "exit"] _, int) => bool = "emit";
+  [@bs.module "process"]
+  external emitMultipleResolves:
+    ([@bs.as "multipleResolves"] _, [@bs.string] [ | `resolve | `reject], Js.Promise.t('a), 'a) =>
+    bool =
+    "emit";
+  [@bs.module "process"]
+  external emitRejectionHandled: ([@bs.as "rejectionHandled"] _, Js.Promise.t('a)) => bool =
+    "emit";
+  [@bs.module "process"]
+  external emitUncaughtException: ([@bs.as "uncaughtException"] _, Js.Exn.t, string) => bool =
+    "emit";
+  [@bs.module "process"]
+  external emitUnhandledRejection:
+    ([@bs.as "unhandledRejection"] _, Js.Exn.t, Js.Promise.t('a)) => bool =
+    "emit";
+};
+include Events;
 type warning = {
   name: string,
   message: string,
   stack: string,
 };
-[@bs.module "process"] [@bs.val]
-external onWarning: ([@bs.as "warning"] _, warning => unit) => unit = "on";
-[@bs.module "process"] [@bs.val] external abort: unit => unit = "abort";
-[@bs.module "process"] [@bs.val] external argv: array(string) = "argv";
-[@bs.module "process"] [@bs.val] external argv0: string = "argv0";
-[@bs.module "process"] [@bs.val] external chdir: string => unit = "chdir";
-[@bs.module "process"] [@bs.val] external cwd: unit => string = "cwd";
-[@bs.module "process"] [@bs.val]
-external disconnect: unit => unit = "disconnect";
-[@bs.module "process"] [@bs.val] external env: Js.Dict.t(string) = "env";
-[@bs.module "process"] [@bs.val]
-external execArgv: array(string) => unit = "execArgv";
-[@bs.module "process"] [@bs.val]
-external execPath: string => unit = "execPath";
-[@bs.module "process"] [@bs.val] external exit: unit => unit = "exit";
-[@bs.module "process"] [@bs.val] external exitWithCode: int => unit = "exit";
-[@bs.module "process"] [@bs.val] external exitCode: int = "exitCode";
-[@bs.module "process"] [@bs.val]
-external nextTick: (unit => unit) => unit = "nextTick";
-[@bs.module "process"] [@bs.val]
-external hrtime: unit => (int, int) = "hrtime";
-[@bs.module "process"] [@bs.scope "hrtime"] [@bs.val]
-external hrtimeBigInt: unit => BigInt.t = "bigint";
-[@bs.module "process"] [@bs.val] external stderr: Stream.t(Buffer.t, [< Net.Socket.kind | Stream.writable ]) = "stderr";
-[@bs.module "process"] [@bs.val] external stdin: Stream.t(Buffer.t, [< Net.Socket.kind | Stream.readable ]) = "stdin";
-[@bs.module "process"] [@bs.val] external stdout: Stream.t(Buffer.t, [< Net.Socket.kind | Stream.writable ]) = "stdout";
-[@bs.module "process"] [@bs.val] external pid: int = "pid";
-[@bs.module "process"] [@bs.val] external platform: string = "platform";
-[@bs.module "process"] [@bs.val] external ppid: int = "ppid";
-[@bs.module "process"] [@bs.val] external uptime: float = "uptime";
-[@bs.module "process"] [@bs.val] external title: string = "title";
-[@bs.module "process"] [@bs.val] external version: string = "version";
-[@bs.module "process"] [@bs.val]
-external versions: Js.Dict.t(string) = "versions";
+[@bs.module "process"] external onWarning: ([@bs.as "warning"] _, warning => unit) => unit = "on";
+[@bs.module "process"] external abort: unit => unit = "abort";
+[@bs.module "process"] external argv: array(string) = "argv";
+[@bs.module "process"] external argv0: string = "argv0";
+[@bs.module "process"] external chdir: string => unit = "chdir";
+[@bs.module "process"] external cwd: unit => string = "cwd";
+[@bs.module "process"] external disconnect: unit => unit = "disconnect";
+[@bs.module "process"] external env: Js.Dict.t(string) = "env";
+[@bs.module "process"] external execArgv: array(string) => unit = "execArgv";
+[@bs.module "process"] external execPath: string => unit = "execPath";
+[@bs.module "process"] external exit: unit => unit = "exit";
+[@bs.module "process"] external exitWithCode: int => unit = "exit";
+[@bs.module "process"] external exitCode: int = "exitCode";
+[@bs.module "process"] external nextTick: (unit => unit) => unit = "nextTick";
+[@bs.module "process"] external hrtime: unit => (int, int) = "hrtime";
+[@bs.module "process"] [@bs.scope "hrtime"] external hrtimeBigInt: unit => BigInt.t = "bigint";
+[@bs.module "process"]
+external stderr: Stream.subtype(Buffer.t, [< Net.Socket.kind | Stream.writable]) = "stderr";
+[@bs.module "process"]
+external stdin: Stream.subtype(Buffer.t, [< Net.Socket.kind | Stream.readable]) = "stdin";
+[@bs.module "process"]
+external stdout: Stream.subtype(Buffer.t, [< Net.Socket.kind | Stream.writable]) = "stdout";
+[@bs.module "process"] external pid: int = "pid";
+[@bs.module "process"] external platform: string = "platform";
+[@bs.module "process"] external ppid: int = "ppid";
+[@bs.module "process"] external uptime: float = "uptime";
+[@bs.module "process"] external title: string = "title";
+[@bs.module "process"] external version: string = "version";
+[@bs.module "process"] external versions: Js.Dict.t(string) = "versions";

--- a/src/Process.re
+++ b/src/Process.re
@@ -1,57 +1,79 @@
-module Events = {
-  [@bs.module "process"] external onBeforeExit: ([@bs.as "beforeExit"] _, (. int) => unit) => unit = "on";
-  [@bs.module "process"] external onDisconnect: ([@bs.as "disconnect"] _, (. unit) => unit) => unit = "on";
-  [@bs.module "process"] external onExit: ([@bs.as "exit"] _, (. int) => unit) => unit = "on";
-  [@bs.module "process"] external onMultipleResolves: ([@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => unit = "on";
-  [@bs.module "process"] external onRejectionHandled: ([@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => unit = "on";
-  [@bs.module "process"] external onUncaughtException: ([@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => unit = "on";
-  [@bs.module "process"] external onUnhandledRejection: ([@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => unit = "on";
+type t;
+[@bs.module] external process: t = "process";
 
-  [@bs.module "process"] external offBeforeExit: ([@bs.as "beforeExit"] _, (. int) => unit) => unit = "off";
-  [@bs.module "process"] external offDisconnect: ([@bs.as "disconnect"] _, (. unit) => unit) => unit = "off";
-  [@bs.module "process"] external offExit: ([@bs.as "exit"] _, (. int) => unit) => unit = "off";
-  [@bs.module "process"] external offMultipleResolves: ([@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => unit = "off";
-  [@bs.module "process"] external offRejectionHandled: ([@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => unit = "off";
-  [@bs.module "process"] external offUncaughtException: ([@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => unit = "off";
-  [@bs.module "process"] external offUnhandledRejection: ([@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => unit = "off";
-
-  [@bs.module "process"] external onBeforeExitOnce: ([@bs.as "beforeExit"] _, (. int) => unit) => unit = "once";
-  [@bs.module "process"] external onDisconnectOnce: ([@bs.as "disconnect"] _, (. unit) => unit) => unit = "once";
-  [@bs.module "process"] external onExitOnce: ([@bs.as "exit"] _, (. int) => unit) => unit = "once";
-  [@bs.module "process"] external onMultipleResolvesOnce: ([@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => unit = "once";
-  [@bs.module "process"] external onRejectionHandledOnce: ([@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => unit = "once";
-  [@bs.module "process"] external onUncaughtExceptionOnce: ([@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => unit = "once";
-  [@bs.module "process"] external onUnhandledRejectionOnce: ([@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => unit = "once";
-};
-include Events;
 type warning = {
   name: string,
   message: string,
   stack: string,
 };
-[@bs.module "process"] external onWarning: ([@bs.as "warning"] _, (. warning) => unit) => unit = "on";
-[@bs.module "process"] external abort: unit => unit = "abort";
-[@bs.module "process"] external argv: array(string) = "argv";
-[@bs.module "process"] external argv0: string = "argv0";
-[@bs.module "process"] external chdir: string => unit = "chdir";
-[@bs.module "process"] external cwd: unit => string = "cwd";
-[@bs.module "process"] external disconnect: unit => unit = "disconnect";
-[@bs.module "process"] external env: Js.Dict.t(string) = "env";
-[@bs.module "process"] external execArgv: array(string) => unit = "execArgv";
-[@bs.module "process"] external execPath: string => unit = "execPath";
-[@bs.module "process"] external exit: unit => unit = "exit";
-[@bs.module "process"] external exitWithCode: int => unit = "exit";
-[@bs.module "process"] external exitCode: int = "exitCode";
-[@bs.module "process"] external nextTick: (unit => unit) => unit = "nextTick";
-[@bs.module "process"] external hrtime: unit => (int, int) = "hrtime";
-[@bs.module "process"] [@bs.scope "hrtime"] external hrtimeBigInt: unit => BigInt.t = "bigint";
-[@bs.module "process"] external stderr: Stream.Writable.subtype(Buffer.t, [< Stream.socket | Stream.writable]) = "stderr";
-[@bs.module "process"] external stdin: Stream.Readable.subtype(Buffer.t, [< Stream.socket | Stream.readable]) = "stdin";
-[@bs.module "process"] external stdout: Stream.Writable.subtype(Buffer.t, [< Stream.socket | Stream.writable]) = "stdout";
-[@bs.module "process"] external pid: int = "pid";
-[@bs.module "process"] external platform: string = "platform";
-[@bs.module "process"] external ppid: int = "ppid";
-[@bs.module "process"] external uptime: float = "uptime";
-[@bs.module "process"] external title: string = "title";
-[@bs.module "process"] external version: string = "version";
-[@bs.module "process"] external versions: Js.Dict.t(string) = "versions";
+
+module Events = {
+  [@bs.send] external onBeforeExit: (t, [@bs.as "beforeExit"] _, (. int) => unit) => t = "on";
+  [@bs.send] external onDisconnect: (t, [@bs.as "disconnect"] _, (. unit) => unit) => t = "on";
+  [@bs.send] external onExit: (t, [@bs.as "exit"] _, (. int) => unit) => t = "on";
+  [@bs.send] external onMultipleResolves: (t, [@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => t = "on";
+  [@bs.send] external onRejectionHandled: (t, [@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => t = "on";
+  [@bs.send] external onUncaughtException: (t, [@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => t = "on";
+  [@bs.send] external onUnhandledRejection: (t, [@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => t = "on";
+  [@bs.send] external onWarning: (t, [@bs.as "warning"] _, (. warning) => unit) => t = "on";
+
+  [@bs.send] external offBeforeExit: (t, [@bs.as "beforeExit"] _, (. int) => unit) => t = "off";
+  [@bs.send] external offDisconnect: (t, [@bs.as "disconnect"] _, (. unit) => unit) => t = "off";
+  [@bs.send] external offExit: (t, [@bs.as "exit"] _, (. int) => unit) => t = "off";
+  [@bs.send] external offMultipleResolves: (t, [@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => t = "off";
+  [@bs.send] external offRejectionHandled: (t, [@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => t = "off";
+  [@bs.send] external offUncaughtException: (t, [@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => t = "off";
+  [@bs.send] external offUnhandledRejection: (t, [@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => t = "off";
+  [@bs.send] external offWarning: (t, [@bs.as "warning"] _, (. warning) => unit) => t = "off";
+
+  [@bs.send] external onBeforeExitOnce: (t, [@bs.as "beforeExit"] _, (. int) => unit) => t = "once";
+  [@bs.send] external onDisconnectOnce: (t, [@bs.as "disconnect"] _, (. unit) => unit) => t = "once";
+  [@bs.send] external onExitOnce: (t, [@bs.as "exit"] _, (. int) => unit) => unit = "once";
+  [@bs.send] external onMultipleResolvesOnce: (t, [@bs.as "multipleResolves"] _, (. string, Js.Promise.t('a), 'a) => unit) => t = "once";
+  [@bs.send] external onRejectionHandledOnce: (t, [@bs.as "rejectionHandled"] _, (. Js.Promise.t('a)) => unit) => t = "once";
+  [@bs.send] external onUncaughtExceptionOnce: (t, [@bs.as "uncaughtException"] _, (. Js.Exn.t, string) => unit) => t = "once";
+  [@bs.send] external onUnhandledRejectionOnce: (t, [@bs.as "unhandledRejection"] _, (. Js.Exn.t, Js.Promise.t('a)) => unit) => t = "once";
+  [@bs.send] external onWarningOnce: (t, [@bs.as "warning"] _, (. warning) => unit) => t = "once";
+
+  [@bs.send] external removeAllListeners: t => t = "removeAllListeners";
+};
+include Events;
+
+[@bs.send] external abort: t => unit = "abort";
+[@bs.get] external argv: t => array(string) = "argv";
+[@bs.get] external argv0: t => string = "argv0";
+[@bs.send] external chdir: (t, string) => unit = "chdir";
+[@bs.send] external cwd: t => string = "cwd";
+[@bs.send] external disconnect: t => unit = "disconnect";
+[@bs.get] external env: t => Js.Dict.t(string) = "env";
+[@bs.get] external execArgv: t => array(string) = "execArgv";
+[@bs.get] external execPath: t => string = "execPath";
+[@bs.send] external exit: (t, unit) => unit = "exit";
+[@bs.send] external exitWithCode: (t, int) => unit = "exit";
+[@bs.get] external exitCode: t => int = "exitCode";
+[@bs.send] external nextTick: (t, unit => unit) => unit = "nextTick";
+[@bs.send] external nextTickApply1: (t, 'a => unit, 'a) => unit = "nextTick";
+[@bs.send] external nextTickApply2: (t, ('a, 'b) => unit, 'a, 'b) => unit = "nextTick";
+[@bs.send] external nextTickApply3: (t, ('a, 'b, 'c) => unit, 'a, 'b, 'c) => unit = "nextTick";
+[@bs.send] external nextTickApply4: (t, ('a, 'b, 'c, 'd) => unit, 'a, 'b, 'c, 'd) => unit = "nextTick";
+[@bs.send] external nextTickApply5: (t, ('a, 'b, 'c, 'd, 'e) => unit, 'a, 'b, 'c, 'd, 'e) => unit = "nextTick";
+[@bs.send] external hrtime: t => (int, int) = "hrtime";
+[@bs.send] [@bs.scope "hrtime"] external hrtimeBigInt: t => BigInt.t = "bigint";
+[@bs.get] external stderr: t => Stream.Writable.subtype(Buffer.t, [< Stream.socket | Stream.writable]) = "stderr";
+[@bs.get] external stdin: t => Stream.Readable.subtype(Buffer.t, [< Stream.socket | Stream.readable]) = "stdin";
+[@bs.get] external stdout: t => Stream.Writable.subtype(Buffer.t, [< Stream.socket | Stream.writable]) = "stdout";
+[@bs.get] external pid: t => int = "pid";
+[@bs.get] external platform: t => string = "platform";
+[@bs.get] external ppid: t => int = "ppid";
+[@bs.get] external uptime: t => float = "uptime";
+[@bs.get] external title: t => string = "title";
+[@bs.get] external version: t => string = "version";
+[@bs.get] external versions: t => Js.Dict.t(string) = "versions";
+type memoryUsageStats = {
+  [@bs.as "rss"] rss: int,
+  [@bs.as "heapTotal"] heapTotal: int,
+  [@bs.as "heapUsed"] heapUsed: int,
+  [@bs.as "external"] external_: int,
+  [@bs.as "arrayBuffers"] arrayBuffers: int,
+};
+[@bs.send] external memoryUsage: t => memoryUsageStats = "memoryUsage";

--- a/src/Readline.re
+++ b/src/Readline.re
@@ -2,8 +2,8 @@ module Interface = {
   type t;
   type interfaceOptions;
   [@bs.obj] external interfaceOptions: (
-    ~input: Stream.t('data, [ Stream.readable ]),
-    ~output: Stream.t('data, [ Stream.writable ])=?,
+    ~input: Stream.subtype('data, [ Stream.readable ]),
+    ~output: Stream.subtype('data, [ Stream.writable ])=?,
     ~completer: (string, (string, (array(string), string)) => unit) => unit=?,
     ~terminal: bool=?,
     ~historySize: int=?,
@@ -44,16 +44,16 @@ module Interface = {
     ) => unit = "write";
   [@bs.get] [@bs.return nullable] external line: t => option(string) = "line";
   [@bs.get] [@bs.return nullable] external cursor: t => option(int) = "cursor";
-  [@bs.send] external clearLine: (t, Stream.t('data, [ Stream.writable ]), int) => bool = "clearLine";
-  [@bs.send] external clearScreenDown: (t, Stream.t('data, Stream.writable), unit => unit) => bool = "clearScreenDown";
+  [@bs.send] external clearLine: (t, Stream.subtype('data, [ Stream.writable ]), int) => bool = "clearLine";
+  [@bs.send] external clearScreenDown: (t, Stream.subtype('data, Stream.writable), unit => unit) => bool = "clearScreenDown";
   [@bs.send] external cursorTo: (
       t,
-      Stream.t('data, Stream.writable),
+      Stream.subtype('data, Stream.writable),
       int,
       Js.Undefined.t(int),
       Js.Undefined.t(unit => unit)
     ) => bool = "cursorTo";
-  [@bs.send] external moveCursor: (t, Stream.t('data, Stream.writable), int, int, Js.Undefined.t(unit => unit)) => bool = "moveCursor";
+  [@bs.send] external moveCursor: (t, Stream.subtype('data, Stream.writable), int, int, Js.Undefined.t(unit => unit)) => bool = "moveCursor";
   
 };
 

--- a/src/Stream.re
+++ b/src/Stream.re
@@ -16,14 +16,13 @@ type objectStream('data, 'a) = t('data, [> objectMode ] as 'a);
 
 module Base = {
   module Events = {
-    [@bs.send] external onError: (t('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "on";
-    [@bs.send] external onClose: (t('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "on";
-    [@bs.send] external offError: (t('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "off";
-    [@bs.send] external offClose: (t('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "off";
-    [@bs.send] external onErrorOnce: (t('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "once";
-    [@bs.send] external onCloseOnce: (t('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "once";
-    [@bs.send] external removeAllListeners: t('data, [> ] as 'a) => t('data, 'a) = "removeAllListeners";
-
+    [@bs.send] external onError: (subtype('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "on";
+    [@bs.send] external onClose: (subtype('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "on";
+    [@bs.send] external offError: (subtype('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "off";
+    [@bs.send] external offClose: (subtype('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "off";
+    [@bs.send] external onErrorOnce: (subtype('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "once";
+    [@bs.send] external onCloseOnce: (subtype('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "once";
+    [@bs.send] external removeAllListeners: subtype('data, [> ] as 'a) => t('data, 'a) = "removeAllListeners";
   };
   module Impl = {
     include Events;
@@ -39,10 +38,16 @@ module Readable = {
     include Base.Events;
     [@bs.send] external onData: (subtype('data, 'a), [@bs.as "data"] _, (. 'data) => unit) => subtype('data, 'a) = "on";
     [@bs.send] external onEnd: (subtype('data, 'a), [@bs.as "end"] _, (. unit) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external onPause: (subtype('data, 'a), [@bs.as "pause"] _, (. unit) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external onReadable: (subtype('data, 'a), [@bs.as "readable"] _, (. unit) => unit) => subtype('data, 'a) = "on";
     [@bs.send] external offData: (subtype('data, 'a), [@bs.as "data"] _, (. 'data) => unit) => subtype('data, 'a) = "off";
     [@bs.send] external offEnd: (subtype('data, 'a), [@bs.as "end"] _, (. unit) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external offPause: (subtype('data, 'a), [@bs.as "pause"] _, (. unit) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external offReadable: (subtype('data, 'a), [@bs.as "readable"] _, (. unit) => unit) => subtype('data, 'a) = "off";
     [@bs.send] external onDataOnce: (subtype('data, 'a), [@bs.as "data"] _, (. 'data) => unit) => subtype('data, 'a) = "once";
     [@bs.send] external onEndOnce: (subtype('data, 'a), [@bs.as "end"] _, (. unit) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onPauseOnce: (subtype('data, 'a), [@bs.as "pause"] _, (. unit) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onReadableOnce: (subtype('data, 'a), [@bs.as "readable"] _, (. unit) => unit) => subtype('data, 'a) = "once";
   };
   module Impl = {
     include Base.Impl;

--- a/src/Stream.re
+++ b/src/Stream.re
@@ -16,13 +16,13 @@ type objectStream('data, 'a) = t('data, [> objectMode ] as 'a);
 
 module Base = {
   module Events = {
-    [@bs.send] external onError: (subtype('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "on";
-    [@bs.send] external onClose: (subtype('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "on";
-    [@bs.send] external offError: (subtype('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "off";
-    [@bs.send] external offClose: (subtype('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "off";
-    [@bs.send] external onErrorOnce: (subtype('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "once";
-    [@bs.send] external onCloseOnce: (subtype('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "once";
-    [@bs.send] external removeAllListeners: subtype('data, [> ] as 'a) => t('data, 'a) = "removeAllListeners";
+    [@bs.send] external onError: (subtype('data, 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "on";
+    [@bs.send] external onClose: (subtype('data, 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "on";
+    [@bs.send] external offError: (subtype('data, 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "off";
+    [@bs.send] external offClose: (subtype('data, 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "off";
+    [@bs.send] external onErrorOnce: (subtype('data, 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "once";
+    [@bs.send] external onCloseOnce: (subtype('data, 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "once";
+    [@bs.send] external removeAllListeners: subtype('data, 'a) => t('data, 'a) = "removeAllListeners";
   };
   module Impl = {
     include Events;

--- a/src/Stream.re
+++ b/src/Stream.re
@@ -170,9 +170,6 @@ module Duplex = {
   [@bs.module "stream"] [@bs.new] external make: unit => t(Buffer.t) = "Duplex";
 };
 
-let test = Duplex.make();
-test -> Duplex.on(`data((. _) => Js.log))
-
 module Transform = {
   type kind = [ transform ];
   type subtype('data, 'a) = t('data, [> kind ] as 'a);

--- a/src/Stream.re
+++ b/src/Stream.re
@@ -15,73 +15,40 @@ type subtype('data, 'a) = t('data, [> ] as 'a);
 type objectStream('data, 'a) = t('data, [> objectMode ] as 'a);
 
 module Base = {
-  module Impl = {
+  module Events = {
     [@bs.send] external onError: (t('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "on";
     [@bs.send] external onClose: (t('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "on";
+    [@bs.send] external offError: (t('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "off";
+    [@bs.send] external offClose: (t('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "off";
+    [@bs.send] external onErrorOnce: (t('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "once";
+    [@bs.send] external onCloseOnce: (t('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "once";
+  };
+  module Impl = {
+    include Events;
   };
   include Impl;
-  module Events = {
-    [@bs.send] external on: (
-      t('data, [> ] as 'a),
-      [@bs.string] [
-        | `error((. Js.Exn.t) => unit)
-        | `close((. unit) => unit)
-      ]
-    ) => t('data, 'a) = "on";
-    [@bs.send] external off: (
-      t('data, [> ] as 'a),
-      [@bs.string] [
-        | `error((. Js.Exn.t) => unit)
-        | `close((. unit) => unit)
-      ]
-    ) => t('data, 'a) = "off";
-    [@bs.send] external once: (
-      t('data, [> ] as 'a),
-      [@bs.string] [
-        | `error((. Js.Exn.t) => unit)
-        | `close((. unit) => unit)
-      ]
-    ) => t('data, 'a) = "once";
-  };
-  include Events;
 };
 
 module Readable = {
   type kind = [ readable ];
   type subtype('data, 'a) = t('data, [> kind ] as 'a);
   type supertype('data, 'a) = t('data, [< kind ] as 'a);
-  module Impl = {
-    include Base.Impl;
+  module Events = {
+    include Base.Events;
     [@bs.send] external onData: (subtype('data, 'a), [@bs.as "data"] _, (. 'data) => unit) => subtype('data, 'a) = "on";
     [@bs.send] external onEnd: (subtype('data, 'a), [@bs.as "end"] _, (. unit) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external offData: (subtype('data, 'a), [@bs.as "data"] _, (. 'data) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external offEnd: (subtype('data, 'a), [@bs.as "end"] _, (. unit) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external onDataOnce: (subtype('data, 'a), [@bs.as "data"] _, (. 'data) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onEndOnce: (subtype('data, 'a), [@bs.as "end"] _, (. unit) => unit) => subtype('data, 'a) = "once";
+  };
+  module Impl = {
+    include Base.Impl;
+    include Events;
     [@bs.send] external pipe: (subtype('data, 'a), t('data, [> writable ]) as 'ws) => 'ws = "pipe";
     [@bs.send] external unpipe: (subtype('data, 'a) as 'rs, t('data, [> writable ])) => 'rs = "unpipe";
   };
   include Impl;
-  module Events = {
-    [@bs.send] external on: (
-      subtype('data, 'a),
-      [@bs.string] [
-        | `data((. 'data) => unit)
-        | `end_((. unit) => unit)
-      ]
-    ) => subtype('data, 'a) = "on";
-    [@bs.send] external off: (
-      subtype('data, 'a),
-      [@bs.string] [
-        | `data((. 'data) => unit)
-        | `end_((. unit) => unit)
-      ]
-    ) => subtype('data, 'a) = "off";
-    [@bs.send] external once: (
-      subtype('data, 'a),
-      [@bs.string] [
-        | `data((. 'data) => unit)
-        | `end_((. unit) => unit)
-      ]
-    ) => subtype('data, 'a) = "once";
-  };
-  include Events;
   type nonrec t('data) = subtype('data, kind);
   type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
   [@bs.module "stream"] [@bs.new] external make: unit => t(Buffer.t) = "Readable";
@@ -91,12 +58,23 @@ module Writable = {
   type kind = [ writable ];
   type subtype('data, 'a) = t('data, [> kind ] as 'a);
   type supertype('data, 'a) = t('data, [< kind ] as 'a);
-  module Impl = {
-    include Base.Impl;
+  module Events = {
     [@bs.send] external onDrain: (subtype('data, 'a), [@bs.as "drain"] _, (. unit) => unit) => subtype('data, 'a) = "on";
     [@bs.send] external onFinish: (subtype('data, 'a), [@bs.as "finish"] _, (. unit) => unit) => subtype('data, 'a) = "on";
     [@bs.send] external onPipe: (subtype('data, 'a), [@bs.as "pipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "on";
     [@bs.send] external onUnpipe: (subtype('data, 'a), [@bs.as "unpipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external offDrain: (subtype('data, 'a), [@bs.as "drain"] _, (. unit) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external offFinish: (subtype('data, 'a), [@bs.as "finish"] _, (. unit) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external offPipe: (subtype('data, 'a), [@bs.as "pipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external offUnpipe: (subtype('data, 'a), [@bs.as "unpipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external onDrainOnce: (subtype('data, 'a), [@bs.as "drain"] _, (. unit) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onFinishOnce: (subtype('data, 'a), [@bs.as "finish"] _, (. unit) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onPipeOnce: (subtype('data, 'a), [@bs.as "pipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onUnpipeOnce: (subtype('data, 'a), [@bs.as "unpipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "once";
+  };
+  module Impl = {
+    include Base.Impl;
+    include Events;
     [@bs.send] external cork: subtype('data, 'a) => unit = "cork";
     [@bs.send] external uncork: subtype('data, 'a) => unit = "uncork";
     [@bs.send] external destroy: subtype('data, 'a) => unit = "destroy";
@@ -115,37 +93,6 @@ module Writable = {
 
   };
   include Impl;
-  module Events = {
-    [@bs.send] external on: (
-      subtype('data, 'a),
-      [@bs.string] [
-        | `drain((. unit) => unit)
-        | `finish((. unit) => unit)
-        | `pipe((. t('data, [> readable ])) => unit)
-        | `unpipe((. t('data, [> readable ])) => unit)
-      ]
-    ) => subtype('data, 'a) = "on";
-    [@bs.send] external off: (
-      subtype('data, 'a),
-      [@bs.string] [
-        | `drain((. unit) => unit)
-        | `finish((. unit) => unit)
-        | `pipe((. t('data, [> readable ])) => unit)
-        | `unpipe((. t('data, [> readable ])) => unit)
-      ]
-    ) => subtype('data, 'a) = "off";
-    [@bs.send] external once: (
-      subtype('data, 'a),
-      [@bs.string] [
-        | `drain((. unit) => unit)
-        | `finish((. unit) => unit)
-        | `pipe((. t('data, [> readable ])) => unit)
-        | `unpipe((. t('data, [> readable ])) => unit)
-      ]
-    ) => subtype('data, 'a) = "once";
-
-  };
-  include Events;
   type nonrec t('data) = subtype('data, kind);
   type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
   [@bs.module "stream"] [@bs.new] external make: unit => t(Buffer.t) = "Writable";
@@ -155,16 +102,16 @@ module Duplex = {
   type kind = [ duplex ];
   type subtype('data, 'a) = t('data, [> kind ] as 'a);
   type supertype('data, 'a) = t('data, [< kind ] as 'a);
-  module Impl = {
-    include Readable.Impl;
-    include Writable.Impl;
-  };
-  include Impl;
   module Events = {
     include Readable.Events;
     include Writable.Events;
   };
-  include Events;
+  module Impl = {
+    include Readable.Impl;
+    include Writable.Impl;
+    include Events;
+  };
+  include Impl;
   type nonrec t('data) = subtype('data, kind);
   type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
   [@bs.module "stream"] [@bs.new] external make: unit => t(Buffer.t) = "Duplex";
@@ -174,14 +121,14 @@ module Transform = {
   type kind = [ transform ];
   type subtype('data, 'a) = t('data, [> kind ] as 'a);
   type supertype('data, 'a) = t('data, [< kind ] as 'a);
-  module Impl = {
-    include Duplex.Impl;
-  };
-  include Impl;
   module Events = {
     include Duplex.Events;
   };
-  include Events;
+  module Impl = {
+    include Duplex.Impl;
+    include Events;
+  };
+  include Impl;
   type nonrec t('data) = subtype('data, kind);
   type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
   type makeOptions;
@@ -200,30 +147,28 @@ module PassThrough = {
   type kind = [ passThrough ];
   type subtype('data, 'a) = t('data, [> kind ] as 'a);
   type supertype('data, 'a) = t('data, [< kind ] as 'a);
-  module Impl = {
-    include Transform.Impl;
-  };
-  include Impl;
   module Events = {
     include Transform.Events;
   };
-  include Events;
+  module Impl = {
+    include Transform.Impl;
+    include Events;
+  };
+  include Impl;
   type nonrec t('data) = subtype('data, kind);
   type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
   [@bs.module "stream"] [@bs.new] external make: unit => t('data) = "PassThrough";
 };
 
-include Base.Impl;
-include Readable.Impl;
-include Writable.Impl;
 module Events = {
   include Base.Events;
   include Readable.Events;
   include Writable.Events;
 };
+include Base.Impl;
+include Readable.Impl;
+include Writable.Impl;
 include Events;
 
-[@bs.send] external onError: (t('data, [> ]), [@bs.as "error"] _, Js.Exn.t => unit) => unit = "on";
-[@bs.send] external onClose: (t('data, [> ]), [@bs.as "close"] _, unit => unit) => unit = "on";
-[@unboxed] type cleanup = {unsubscribe: unit => unit};
-[@bs.module "stream"] [@bs.val] external finished: (t('data, [> ]), option(Js.Exn.t) => unit) => cleanup = "finished";
+type cleanupFn = unit => unit;
+[@bs.module "stream"] [@bs.val] external finished: (t('data, [> ]), option(Js.Exn.t) => unit) => cleanupFn = "finished";

--- a/src/Stream.re
+++ b/src/Stream.re
@@ -1,9 +1,6 @@
 /**
  * This section contains most of polymorphic variant constraints
  * corresponding to the various subtypes of `Stream.t` throughout this library.
- * These are the "canonical" constraint types. for the sake of consistency
- * and correctness, User code should use these type aliases rather than writing
- * the polymorphic variants directly.
  */
 type readable = [ `Readable ];
 type writable = [ `Writable ];
@@ -19,10 +16,34 @@ type objectStream('data, 'a) = t('data, [> objectMode ] as 'a);
 
 module Base = {
   module Impl = {
-    [@bs.send] external onError: (t('data, [> ]), [@bs.as "error"] _, Js.Exn.t => unit) => unit = "on";
-    [@bs.send] external onClose: (t('data, [> ]), [@bs.as "close"] _, unit => unit) => unit = "on";
-  }
+    [@bs.send] external onError: (t('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "on";
+    [@bs.send] external onClose: (t('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "on";
+  };
   include Impl;
+  module Events = {
+    [@bs.send] external on: (
+      t('data, [> ] as 'a),
+      [@bs.string] [
+        | `error((. Js.Exn.t) => unit)
+        | `close((. unit) => unit)
+      ]
+    ) => t('data, 'a) = "on";
+    [@bs.send] external off: (
+      t('data, [> ] as 'a),
+      [@bs.string] [
+        | `error((. Js.Exn.t) => unit)
+        | `close((. unit) => unit)
+      ]
+    ) => t('data, 'a) = "off";
+    [@bs.send] external once: (
+      t('data, [> ] as 'a),
+      [@bs.string] [
+        | `error((. Js.Exn.t) => unit)
+        | `close((. unit) => unit)
+      ]
+    ) => t('data, 'a) = "once";
+  };
+  include Events;
 };
 
 module Readable = {
@@ -31,14 +52,38 @@ module Readable = {
   type supertype('data, 'a) = t('data, [< kind ] as 'a);
   module Impl = {
     include Base.Impl;
-    [@bs.send] external onData: (subtype('data, 'a), [@bs.as "data"] _, 'data => unit) => unit = "on";
-    [@bs.send] external onEnd: (subtype('data, 'a), [@bs.as "end"] _, unit => unit) => unit = "on";
+    [@bs.send] external onData: (subtype('data, 'a), [@bs.as "data"] _, (. 'data) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external onEnd: (subtype('data, 'a), [@bs.as "end"] _, (. unit) => unit) => subtype('data, 'a) = "on";
     [@bs.send] external pipe: (subtype('data, 'a), t('data, [> writable ]) as 'ws) => 'ws = "pipe";
     [@bs.send] external unpipe: (subtype('data, 'a) as 'rs, t('data, [> writable ])) => 'rs = "unpipe";
   };
   include Impl;
+  module Events = {
+    [@bs.send] external on: (
+      subtype('data, 'a),
+      [@bs.string] [
+        | `data((. 'data) => unit)
+        | `end_((. unit) => unit)
+      ]
+    ) => subtype('data, 'a) = "on";
+    [@bs.send] external off: (
+      subtype('data, 'a),
+      [@bs.string] [
+        | `data((. 'data) => unit)
+        | `end_((. unit) => unit)
+      ]
+    ) => subtype('data, 'a) = "off";
+    [@bs.send] external once: (
+      subtype('data, 'a),
+      [@bs.string] [
+        | `data((. 'data) => unit)
+        | `end_((. unit) => unit)
+      ]
+    ) => subtype('data, 'a) = "once";
+  };
+  include Events;
   type nonrec t('data) = subtype('data, kind);
-  type nonrec objectStream('data) = objectStream('data, [ readable | objectMode ]);
+  type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
   [@bs.module "stream"] [@bs.new] external make: unit => t(Buffer.t) = "Readable";
 };
 
@@ -48,10 +93,10 @@ module Writable = {
   type supertype('data, 'a) = t('data, [< kind ] as 'a);
   module Impl = {
     include Base.Impl;
-    [@bs.send] external onDrain: (subtype('data, 'a), [@bs.as "drain"] _, unit => unit) => unit = "on";
-    [@bs.send] external onFinish: (subtype('data, 'a), [@bs.as "finish"] _, unit => unit) => unit = "on";
-    [@bs.send] external onPipe: (subtype('data, 'a), [@bs.as "pipe"] _, t('data, [> readable]) => unit) => unit = "on";
-    [@bs.send] external onUnpipe: (subtype('data, 'a), [@bs.as "unpipe"] _, t('data, [> readable]) => unit) => unit = "on";
+    [@bs.send] external onDrain: (subtype('data, 'a), [@bs.as "drain"] _, (. unit) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external onFinish: (subtype('data, 'a), [@bs.as "finish"] _, (. unit) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external onPipe: (subtype('data, 'a), [@bs.as "pipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external onUnpipe: (subtype('data, 'a), [@bs.as "unpipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "on";
     [@bs.send] external cork: subtype('data, 'a) => unit = "cork";
     [@bs.send] external uncork: subtype('data, 'a) => unit = "uncork";
     [@bs.send] external destroy: subtype('data, 'a) => unit = "destroy";
@@ -67,12 +112,43 @@ module Writable = {
     [@bs.get] external writableLength: subtype('data, 'a) => int = "writableLength";
     [@bs.get] external writableHighWaterMark: subtype('data, 'a) => int = "writableHighWaterMark";
     [@bs.get] external writableObjectMode: subtype('data, 'a) => bool = "writableObjectMode";
+
   };
   include Impl;
-  type nonrec t('data) = subtype('data, kind);
-  type nonrec objectStream('data) = objectStream('data, [ writable | objectMode ]);
-  [@bs.module "stream"] [@bs.new] external make: unit => t(Buffer.t) = "Writable";
+  module Events = {
+    [@bs.send] external on: (
+      subtype('data, 'a),
+      [@bs.string] [
+        | `drain((. unit) => unit)
+        | `finish((. unit) => unit)
+        | `pipe((. t('data, [> readable ])) => unit)
+        | `unpipe((. t('data, [> readable ])) => unit)
+      ]
+    ) => subtype('data, 'a) = "on";
+    [@bs.send] external off: (
+      subtype('data, 'a),
+      [@bs.string] [
+        | `drain((. unit) => unit)
+        | `finish((. unit) => unit)
+        | `pipe((. t('data, [> readable ])) => unit)
+        | `unpipe((. t('data, [> readable ])) => unit)
+      ]
+    ) => subtype('data, 'a) = "off";
+    [@bs.send] external once: (
+      subtype('data, 'a),
+      [@bs.string] [
+        | `drain((. unit) => unit)
+        | `finish((. unit) => unit)
+        | `pipe((. t('data, [> readable ])) => unit)
+        | `unpipe((. t('data, [> readable ])) => unit)
+      ]
+    ) => subtype('data, 'a) = "once";
 
+  };
+  include Events;
+  type nonrec t('data) = subtype('data, kind);
+  type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
+  [@bs.module "stream"] [@bs.new] external make: unit => t(Buffer.t) = "Writable";
 };
 
 module Duplex = {
@@ -84,10 +160,18 @@ module Duplex = {
     include Writable.Impl;
   };
   include Impl;
-  type nonrec t('data) = t('data, [ duplex ]);
-  type nonrec objectStream('data) = objectStream('data, [ duplex | objectMode ]);
+  module Events = {
+    include Readable.Events;
+    include Writable.Events;
+  };
+  include Events;
+  type nonrec t('data) = subtype('data, kind);
+  type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
   [@bs.module "stream"] [@bs.new] external make: unit => t(Buffer.t) = "Duplex";
 };
+
+let test = Duplex.make();
+test -> Duplex.on(`data((. _) => Js.log))
 
 module Transform = {
   type kind = [ transform ];
@@ -97,39 +181,50 @@ module Transform = {
     include Duplex.Impl;
   };
   include Impl;
+  module Events = {
+    include Duplex.Events;
+  };
+  include Events;
+  type nonrec t('data) = subtype('data, kind);
+  type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
   type makeOptions;
   [@bs.obj] external makeOptions: (
     ~transform: (
         ~chunk: Buffer.t,
-        ~encoding: string,
-        ~callback: (option(Js.Exn.t), Buffer.t) => unit
+        ~callback: (. option(Js.Exn.t), Buffer.t) => unit
       ) => Buffer.t,
     ~flush: (option(Js.Exn.t), Buffer.t) => unit
   ) => makeOptions = "";
-  type nonrec t = t(Buffer.t, [ transform ]);
-  type nonrec objectStream('data) = objectStream('data, [ transform | objectMode ]);
-  [@bs.module "stream"] [@bs.new] external make: unit => t = "Transform";
-  [@bs.module "stream"] [@bs.new] external makeWith: (~options: makeOptions) => t = "Transform";
-
-  // [@bs.module "stream"] [@bs.new] external makeObjectMode: unit => t = "Transform";
-  // [@bs.module "stream"] [@bs.new] external makeObjectModeWith: (~options: makeOptions) => t = "Transform";
-
+  [@bs.module "stream"] [@bs.new] external make: unit => t(Buffer.t) = "Transform";
+  [@bs.module "stream"] [@bs.new] external makeWith: (~options: makeOptions) => t(Buffer.t) = "Transform";
 };
 
 module PassThrough = {
   type kind = [ passThrough ];
+  type subtype('data, 'a) = t('data, [> kind ] as 'a);
+  type supertype('data, 'a) = t('data, [< kind ] as 'a);
   module Impl = {
     include Transform.Impl;
   };
   include Impl;
-  type objectMode('data) = t('data, [ passThrough | `ObjectMode ]);
-  type nonrec t = t(Buffer.t, [ passThrough ]);
-  [@bs.module "stream"] [@bs.new] external make: unit => t = "PassThrough";
+  module Events = {
+    include Transform.Events;
+  };
+  include Events;
+  type nonrec t('data) = subtype('data, kind);
+  type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
+  [@bs.module "stream"] [@bs.new] external make: unit => t('data) = "PassThrough";
 };
 
 include Base.Impl;
 include Readable.Impl;
 include Writable.Impl;
+module Events = {
+  include Base.Events;
+  include Readable.Events;
+  include Writable.Events;
+};
+include Events;
 
 [@bs.send] external onError: (t('data, [> ]), [@bs.as "error"] _, Js.Exn.t => unit) => unit = "on";
 [@bs.send] external onClose: (t('data, [> ]), [@bs.as "close"] _, unit => unit) => unit = "on";

--- a/src/Stream.re
+++ b/src/Stream.re
@@ -22,6 +22,8 @@ module Base = {
     [@bs.send] external offClose: (t('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "off";
     [@bs.send] external onErrorOnce: (t('data, [> ] as 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "once";
     [@bs.send] external onCloseOnce: (t('data, [> ] as 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "once";
+    [@bs.send] external removeAllListeners: t('data, [> ] as 'a) => t('data, 'a) = "removeAllListeners";
+
   };
   module Impl = {
     include Events;

--- a/src/Stream.re
+++ b/src/Stream.re
@@ -2,27 +2,28 @@
  * This section contains most of polymorphic variant constraints
  * corresponding to the various subtypes of `Stream.t` throughout this library.
  */
-type readable = [ `Readable ];
-type writable = [ `Writable ];
-type duplex = [ readable | writable ];
-type transform = [ duplex | `Transform ];
-type passThrough = [ transform | `PassThrough ];
-type socket = [ `Socket ];
-type objectMode = [ `ObjectMode ];
+type stream = [ `Stream ];
+type readable = [ stream | `Readable ];
+type writable = [  stream | `Writable ];
+type duplex = [ stream | readable | writable ];
+type transform = [ stream | duplex | `Transform ];
+type passThrough = [ stream | transform | `PassThrough ];
+type socket = [ stream | `Socket ];
+type objectMode = [ stream | `ObjectMode ];
 
-type t('data, 'a);
-type subtype('data, 'a) = t('data, [> ] as 'a);
-type objectStream('data, 'a) = t('data, [> objectMode ] as 'a);
+type subtype('data, 'a) constraint 'a = [> ];
+type objectStream('data, 'a) constraint 'a = [> ];
+type t('data) = subtype('data, stream);
 
 module Base = {
   module Events = {
-    [@bs.send] external onError: (subtype('data, 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "on";
-    [@bs.send] external onClose: (subtype('data, 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "on";
-    [@bs.send] external offError: (subtype('data, 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "off";
-    [@bs.send] external offClose: (subtype('data, 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "off";
-    [@bs.send] external onErrorOnce: (subtype('data, 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('data, 'a) = "once";
-    [@bs.send] external onCloseOnce: (subtype('data, 'a), [@bs.as "close"] _, (. unit) => unit) => t('data, 'a) = "once";
-    [@bs.send] external removeAllListeners: subtype('data, 'a) => t('data, 'a) = "removeAllListeners";
+    [@bs.send] external onError: (subtype('data, 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external onClose: (subtype('data, 'a), [@bs.as "close"] _, (. unit) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external offError: (subtype('data, 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external offClose: (subtype('data, 'a), [@bs.as "close"] _, (. unit) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external onErrorOnce: (subtype('data, 'a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onCloseOnce: (subtype('data, 'a), [@bs.as "close"] _, (. unit) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external removeAllListeners: subtype('data, 'a) => subtype('data, 'a) = "removeAllListeners";
   };
   module Impl = {
     include Events;
@@ -32,30 +33,30 @@ module Base = {
 
 module Readable = {
   type kind = [ readable ];
-  type subtype('data, 'a) = t('data, [> kind ] as 'a);
-  type supertype('data, 'a) = t('data, [< kind ] as 'a);
   module Events = {
     include Base.Events;
-    [@bs.send] external onData: (subtype('data, 'a), [@bs.as "data"] _, (. 'data) => unit) => subtype('data, 'a) = "on";
-    [@bs.send] external onEnd: (subtype('data, 'a), [@bs.as "end"] _, (. unit) => unit) => subtype('data, 'a) = "on";
-    [@bs.send] external onPause: (subtype('data, 'a), [@bs.as "pause"] _, (. unit) => unit) => subtype('data, 'a) = "on";
-    [@bs.send] external onReadable: (subtype('data, 'a), [@bs.as "readable"] _, (. unit) => unit) => subtype('data, 'a) = "on";
-    [@bs.send] external offData: (subtype('data, 'a), [@bs.as "data"] _, (. 'data) => unit) => subtype('data, 'a) = "off";
-    [@bs.send] external offEnd: (subtype('data, 'a), [@bs.as "end"] _, (. unit) => unit) => subtype('data, 'a) = "off";
-    [@bs.send] external offPause: (subtype('data, 'a), [@bs.as "pause"] _, (. unit) => unit) => subtype('data, 'a) = "off";
-    [@bs.send] external offReadable: (subtype('data, 'a), [@bs.as "readable"] _, (. unit) => unit) => subtype('data, 'a) = "off";
-    [@bs.send] external onDataOnce: (subtype('data, 'a), [@bs.as "data"] _, (. 'data) => unit) => subtype('data, 'a) = "once";
-    [@bs.send] external onEndOnce: (subtype('data, 'a), [@bs.as "end"] _, (. unit) => unit) => subtype('data, 'a) = "once";
-    [@bs.send] external onPauseOnce: (subtype('data, 'a), [@bs.as "pause"] _, (. unit) => unit) => subtype('data, 'a) = "once";
-    [@bs.send] external onReadableOnce: (subtype('data, 'a), [@bs.as "readable"] _, (. unit) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onData: (subtype('data, [> kind ] as 'a), [@bs.as "data"] _, (. 'data) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external onEnd: (subtype('data, [> kind ] as 'a), [@bs.as "end"] _, (. unit) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external onPause: (subtype('data, [> kind ] as 'a), [@bs.as "pause"] _, (. unit) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external onReadable: (subtype('data, [> kind ] as 'a), [@bs.as "readable"] _, (. unit) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external offData: (subtype('data, [> kind ] as 'a), [@bs.as "data"] _, (. 'data) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external offEnd: (subtype('data, [> kind ] as 'a), [@bs.as "end"] _, (. unit) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external offPause: (subtype('data, [> kind ] as 'a), [@bs.as "pause"] _, (. unit) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external offReadable: (subtype('data, [> kind ] as 'a), [@bs.as "readable"] _, (. unit) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external onDataOnce: (subtype('data, [> kind ] as 'a), [@bs.as "data"] _, (. 'data) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onEndOnce: (subtype('data, [> kind ] as 'a), [@bs.as "end"] _, (. unit) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onPauseOnce: (subtype('data, [> kind ] as 'a), [@bs.as "pause"] _, (. unit) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onReadableOnce: (subtype('data, [> kind ] as 'a), [@bs.as "readable"] _, (. unit) => unit) => subtype('data, 'a) = "once";
   };
   module Impl = {
     include Base.Impl;
     include Events;
-    [@bs.send] external pipe: (subtype('data, 'a), t('data, [> writable ]) as 'ws) => 'ws = "pipe";
-    [@bs.send] external unpipe: (subtype('data, 'a) as 'rs, t('data, [> writable ])) => 'rs = "unpipe";
+    [@bs.send] external pipe: (subtype('data, [> kind ] as 'a), subtype('data, [> writable ]) as 'ws) => 'ws = "pipe";
+    [@bs.send] external unpipe: (subtype('data, [> kind ] as 'a) as 'rs, subtype('data, [> writable ])) => 'rs = "unpipe";
   };
   include Impl;
+  type nonrec subtype('data, 'a) = subtype('data, [> kind ] as 'a);
+  type nonrec supertype('data, 'a) = subtype('data, [< kind ] as 'a);
   type nonrec t('data) = subtype('data, kind);
   type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
   [@bs.module "stream"] [@bs.new] external make: unit => t(Buffer.t) = "Readable";
@@ -63,43 +64,43 @@ module Readable = {
 
 module Writable = {
   type kind = [ writable ];
-  type subtype('data, 'a) = t('data, [> kind ] as 'a);
-  type supertype('data, 'a) = t('data, [< kind ] as 'a);
   module Events = {
-    [@bs.send] external onDrain: (subtype('data, 'a), [@bs.as "drain"] _, (. unit) => unit) => subtype('data, 'a) = "on";
-    [@bs.send] external onFinish: (subtype('data, 'a), [@bs.as "finish"] _, (. unit) => unit) => subtype('data, 'a) = "on";
-    [@bs.send] external onPipe: (subtype('data, 'a), [@bs.as "pipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "on";
-    [@bs.send] external onUnpipe: (subtype('data, 'a), [@bs.as "unpipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "on";
-    [@bs.send] external offDrain: (subtype('data, 'a), [@bs.as "drain"] _, (. unit) => unit) => subtype('data, 'a) = "off";
-    [@bs.send] external offFinish: (subtype('data, 'a), [@bs.as "finish"] _, (. unit) => unit) => subtype('data, 'a) = "off";
-    [@bs.send] external offPipe: (subtype('data, 'a), [@bs.as "pipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "off";
-    [@bs.send] external offUnpipe: (subtype('data, 'a), [@bs.as "unpipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "off";
-    [@bs.send] external onDrainOnce: (subtype('data, 'a), [@bs.as "drain"] _, (. unit) => unit) => subtype('data, 'a) = "once";
-    [@bs.send] external onFinishOnce: (subtype('data, 'a), [@bs.as "finish"] _, (. unit) => unit) => subtype('data, 'a) = "once";
-    [@bs.send] external onPipeOnce: (subtype('data, 'a), [@bs.as "pipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "once";
-    [@bs.send] external onUnpipeOnce: (subtype('data, 'a), [@bs.as "unpipe"] _, (. t('data, [> readable])) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onDrain: (subtype('data, [> kind ] as 'a), [@bs.as "drain"] _, (. unit) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external onFinish: (subtype('data, [> kind ] as 'a), [@bs.as "finish"] _, (. unit) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external onPipe: (subtype('data, [> kind ] as 'a), [@bs.as "pipe"] _, (. subtype('data, [> readable])) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external onUnpipe: (subtype('data, [> kind ] as 'a), [@bs.as "unpipe"] _, (. subtype('data, [> readable])) => unit) => subtype('data, 'a) = "on";
+    [@bs.send] external offDrain: (subtype('data, [> kind ] as 'a), [@bs.as "drain"] _, (. unit) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external offFinish: (subtype('data, [> kind ] as 'a), [@bs.as "finish"] _, (. unit) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external offPipe: (subtype('data, [> kind ] as 'a), [@bs.as "pipe"] _, (. subtype('data, [> readable])) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external offUnpipe: (subtype('data, [> kind ] as 'a), [@bs.as "unpipe"] _, (. subtype('data, [> readable])) => unit) => subtype('data, 'a) = "off";
+    [@bs.send] external onDrainOnce: (subtype('data, [> kind ] as 'a), [@bs.as "drain"] _, (. unit) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onFinishOnce: (subtype('data, [> kind ] as 'a), [@bs.as "finish"] _, (. unit) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onPipeOnce: (subtype('data, [> kind ] as 'a), [@bs.as "pipe"] _, (. subtype('data, [> readable])) => unit) => subtype('data, 'a) = "once";
+    [@bs.send] external onUnpipeOnce: (subtype('data, [> kind ] as 'a), [@bs.as "unpipe"] _, (. subtype('data, [> readable])) => unit) => subtype('data, 'a) = "once";
   };
   module Impl = {
     include Base.Impl;
     include Events;
-    [@bs.send] external cork: subtype('data, 'a) => unit = "cork";
-    [@bs.send] external uncork: subtype('data, 'a) => unit = "uncork";
-    [@bs.send] external destroy: subtype('data, 'a) => unit = "destroy";
-    [@bs.send] external destroyWithError: (subtype('data, 'a), Js.Exn.t) => unit = "destroy";
-    [@bs.get] external destroyed: subtype('data, 'a) => bool = "destroy";
-    [@bs.send] external end_: subtype('data, 'a) => unit = "end";
-    [@bs.send] external write: (subtype('data, 'a), 'data) => bool = "write";
-    [@bs.send] external writeWith: (subtype('data, 'a), 'data , ~callback: Js.Nullable.t(Js.Exn.t) => unit=?, unit) => bool = "write";
-    [@bs.get] external writable: subtype('data, 'a) => bool = "writable";
-    [@bs.get] external writableEnded: subtype('data, 'a) => bool = "writableEnded";
-    [@bs.get] external writableCorked: subtype('data, 'a) => bool = "writableCorked";
-    [@bs.get] external writableFinished: subtype('data, 'a) => bool = "writableFinished";
-    [@bs.get] external writableLength: subtype('data, 'a) => int = "writableLength";
-    [@bs.get] external writableHighWaterMark: subtype('data, 'a) => int = "writableHighWaterMark";
-    [@bs.get] external writableObjectMode: subtype('data, 'a) => bool = "writableObjectMode";
+    [@bs.send] external cork: subtype('data, [> kind ] as 'a) => unit = "cork";
+    [@bs.send] external uncork: subtype('data, [> kind ] as 'a) => unit = "uncork";
+    [@bs.send] external destroy: subtype('data, [> kind ] as 'a) => unit = "destroy";
+    [@bs.send] external destroyWithError: (subtype('data, [> kind ] as 'a), Js.Exn.t) => unit = "destroy";
+    [@bs.get] external destroyed: subtype('data, [> kind ] as 'a) => bool = "destroy";
+    [@bs.send] external end_: subtype('data, [> kind ] as 'a) => unit = "end";
+    [@bs.send] external write: (subtype('data, [> kind ] as 'a), 'data) => bool = "write";
+    [@bs.send] external writeWith: (subtype('data, [> kind ] as 'a), 'data , ~callback: Js.Nullable.t(Js.Exn.t) => unit=?, unit) => bool = "write";
+    [@bs.get] external writable: subtype('data, [> kind ] as 'a) => bool = "writable";
+    [@bs.get] external writableEnded: subtype('data, [> kind ] as 'a) => bool = "writableEnded";
+    [@bs.get] external writableCorked: subtype('data, [> kind ] as 'a) => bool = "writableCorked";
+    [@bs.get] external writableFinished: subtype('data, [> kind ] as 'a) => bool = "writableFinished";
+    [@bs.get] external writableLength: subtype('data, [> kind ] as 'a) => int = "writableLength";
+    [@bs.get] external writableHighWaterMark: subtype('data, [> kind ] as 'a) => int = "writableHighWaterMark";
+    [@bs.get] external writableObjectMode: subtype('data, [> kind ] as 'a) => bool = "writableObjectMode";
 
   };
   include Impl;
+  type nonrec subtype('data, 'a) = subtype('data, [> kind ] as 'a);
+  type nonrec supertype('data, 'a) = subtype('data, [< kind ] as 'a);
   type nonrec t('data) = subtype('data, kind);
   type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
   [@bs.module "stream"] [@bs.new] external make: unit => t(Buffer.t) = "Writable";
@@ -107,8 +108,6 @@ module Writable = {
 
 module Duplex = {
   type kind = [ duplex ];
-  type subtype('data, 'a) = t('data, [> kind ] as 'a);
-  type supertype('data, 'a) = t('data, [< kind ] as 'a);
   module Events = {
     include Readable.Events;
     include Writable.Events;
@@ -119,6 +118,8 @@ module Duplex = {
     include Events;
   };
   include Impl;
+  type nonrec subtype('data, 'a) = subtype('data, [> kind ] as 'a);
+  type nonrec supertype('data, 'a) = subtype('data, [< kind ] as 'a);
   type nonrec t('data) = subtype('data, kind);
   type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
   [@bs.module "stream"] [@bs.new] external make: unit => t(Buffer.t) = "Duplex";
@@ -126,8 +127,6 @@ module Duplex = {
 
 module Transform = {
   type kind = [ transform ];
-  type subtype('data, 'a) = t('data, [> kind ] as 'a);
-  type supertype('data, 'a) = t('data, [< kind ] as 'a);
   module Events = {
     include Duplex.Events;
   };
@@ -136,6 +135,8 @@ module Transform = {
     include Events;
   };
   include Impl;
+  type nonrec subtype('data, 'a) = subtype('data, [> kind ] as 'a);
+  type nonrec supertype('data, 'a) = subtype('data, [< kind ] as 'a);
   type nonrec t('data) = subtype('data, kind);
   type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
   type makeOptions;
@@ -152,8 +153,6 @@ module Transform = {
 
 module PassThrough = {
   type kind = [ passThrough ];
-  type subtype('data, 'a) = t('data, [> kind ] as 'a);
-  type supertype('data, 'a) = t('data, [< kind ] as 'a);
   module Events = {
     include Transform.Events;
   };
@@ -162,6 +161,8 @@ module PassThrough = {
     include Events;
   };
   include Impl;
+  type nonrec subtype('data, 'a) = subtype('data, [> kind ] as 'a);
+  type nonrec supertype('data, 'a) = subtype('data, [< kind ] as 'a);
   type nonrec t('data) = subtype('data, kind);
   type nonrec objectStream('data) = subtype('data, [ kind | objectMode ]);
   [@bs.module "stream"] [@bs.new] external make: unit => t('data) = "PassThrough";
@@ -178,4 +179,4 @@ include Writable.Impl;
 include Events;
 
 type cleanupFn = unit => unit;
-[@bs.module "stream"] [@bs.val] external finished: (t('data, [> ]), option(Js.Exn.t) => unit) => cleanupFn = "finished";
+[@bs.module "stream"] [@bs.val] external finished: (subtype('data, [> ]), option(Js.Exn.t) => unit) => cleanupFn = "finished";

--- a/src/Tls.re
+++ b/src/Tls.re
@@ -5,6 +5,9 @@ module TlsSocket = {
   type subtype('a) = Net.Socket.subtype([> kind ] as 'a);
   type supertype('a) = Net.Socket.subtype([< kind ] as 'a);
   type t = Net.TcpSocket.subtype(kind);
+  module Events = {
+    include Net.TcpSocket.Events;
+  };
   module Impl = {
     include Net.TcpSocket.Impl;
   };
@@ -17,6 +20,9 @@ module TlsServer = {
   type subtype('a) = Net.Server.subtype([> kind ] as 'a);
   type supertype('a) = Net.Server.subtype([< kind ] as 'a);
   type t = subtype(kind);
+  module Events = {
+    include Net.TcpServer.Events;
+  };
   module Impl = {
     include Net.TcpServer.Impl;
   };

--- a/src/Tls.re
+++ b/src/Tls.re
@@ -10,6 +10,7 @@ module TlsSocket = {
   };
   module Impl = {
     include Net.TcpSocket.Impl;
+    include Events;
   };
   include Impl;
 };
@@ -25,6 +26,7 @@ module TlsServer = {
   };
   module Impl = {
     include Net.TcpServer.Impl;
+    include Events;
   };
   include Impl;
 };

--- a/src/Tls.re
+++ b/src/Tls.re
@@ -17,8 +17,8 @@ module TlsServer = {
   type subtype('a) = Net.Server.subtype([> kind ] as 'a);
   type supertype('a) = Net.Server.subtype([< kind ] as 'a);
   type t = subtype(kind);
-  module Impl = (T: { type t; }) => {
-    include Net.TcpServer.Impl(T);
+  module Impl = {
+    include Net.TcpServer.Impl;
   };
-  include Impl({ type nonrec t = t; });
+  include Impl;
 };

--- a/src/WorkerThreads.re
+++ b/src/WorkerThreads.re
@@ -13,8 +13,8 @@
 
 module MessagePort = {
   type t('a);
-  [@bs.send] external onClose: (t('a), [@bs.as "close"] _, unit => unit) => unit = "on";
-  [@bs.send] external onMessage: (t('a), [@bs.as "message"] _, 'a => unit) => unit = "on";
+  [@bs.send] external onClose: (t('a), [@bs.as "close"] _, (. unit) => unit) => t('a) = "on";
+  [@bs.send] external onMessage: (t('a), [@bs.as "message"] _, (. 'a) => unit) => t('a) = "on";
   [@bs.send] external close: t('a) => unit = "close";
   [@bs.send] external postMessage: (t('a), 'a) => unit = "postMessage";
   [@bs.send] external ref: t('a) => unit = "ref";
@@ -25,8 +25,8 @@ module MessagePort = {
     type message;
   }) => {
     type nonrec t = t(T.message);
-    [@bs.send] external onClose: (t, [@bs.as "close"] _, unit => unit) => unit = "on";
-    [@bs.send] external onMessage: (t, [@bs.as "message"] _, T.message => unit) => unit = "on";
+    [@bs.send] external onClose: (t, [@bs.as "close"] _, (. unit) => unit) => t = "on";
+    [@bs.send] external onMessage: (t, [@bs.as "message"] _, (. T.message) => unit) => t = "on";
     [@bs.send] external close: t => unit = "close";
     [@bs.send] external postMessage: (t, T.message) => unit = "postMessage";
     [@bs.send] external ref: t => unit = "ref";
@@ -79,10 +79,10 @@ module Worker = {
   ) => makeOptions('a) = "";
 
   [@bs.module "worker_threads"] [@bs.new] external make: (~file: string, ~options: makeOptions('a)=?, unit) => t('a) = "Worker";
-  [@bs.send] external onError: (t('a), [@bs.as "error"] _, Js.Exn.t => unit) => unit = "on";
-  [@bs.send] external onMessage: (t('a), [@bs.as "message"] _, 'a => unit) => unit = "on";
-  [@bs.send] external onExit: (t('a), [@bs.as "exit"] _, int => unit) => unit = "on";
-  [@bs.send] external onOnline: (t('a), [@bs.as "online"] _, unit => unit) => unit = "on";
+  [@bs.send] external onError: (t('a), [@bs.as "error"] _, (. Js.Exn.t) => unit) => t('a) = "on";
+  [@bs.send] external onMessage: (t('a), [@bs.as "message"] _, (. 'a) => unit) => t('a) = "on";
+  [@bs.send] external onExit: (t('a), [@bs.as "exit"] _, (. int) => unit) => t('a) = "on";
+  [@bs.send] external onOnline: (t('a), [@bs.as "online"] _, (. unit) => unit) => t('a) = "on";
   [@bs.send] external postMessage: (t('a), 'a) => unit = "postMessage";
   [@bs.send] external ref: t('a) => unit = "ref";
   [@bs.send] external resourceLimits: t('a) => workerResourceLimits = "workerResourceLimits";
@@ -114,10 +114,10 @@ module Worker = {
     ) => makeOptions = "";
 
     [@bs.module "worker_threads"] [@bs.new] external make: (~file: string, ~options: makeOptions=?, unit) => t = "Worker";
-    [@bs.send] external onError: (t, [@bs.as "error"] _, Js.Exn.t => unit) => unit = "on";
-    [@bs.send] external onMessage: (t, [@bs.as "message"] _, T.message => unit) => unit = "on";
-    [@bs.send] external onExit: (t, [@bs.as "exit"] _, int => unit) => unit = "on";
-    [@bs.send] external onOnline: (t, [@bs.as "online"] _, unit => unit) => unit = "on";
+    [@bs.send] external onError: (t, [@bs.as "error"] _, (. Js.Exn.t) => unit) => t = "on";
+    [@bs.send] external onMessage: (t, [@bs.as "message"] _, (. T.message) => unit) => t = "on";
+    [@bs.send] external onExit: (t, [@bs.as "exit"] _, (. int) => unit) => t = "on";
+    [@bs.send] external onOnline: (t, [@bs.as "online"] _, (. unit) => unit) => t = "on";
     [@bs.send] external postMessage: (t, T.message) => unit = "postMessage";
     [@bs.send] external ref: t => unit = "ref";
     [@bs.send] external resourceLimits: t => workerResourceLimits = "workerResourceLimits";

--- a/src/WorkerThreads.re
+++ b/src/WorkerThreads.re
@@ -11,7 +11,6 @@
  * We should revisit this with concrete tests to determine the best design.
  */
 
-
 module MessagePort = {
   type t('a);
   [@bs.send] external onClose: (t('a), [@bs.as "close"] _, unit => unit) => unit = "on";
@@ -87,9 +86,9 @@ module Worker = {
   [@bs.send] external postMessage: (t('a), 'a) => unit = "postMessage";
   [@bs.send] external ref: t('a) => unit = "ref";
   [@bs.send] external resourceLimits: t('a) => workerResourceLimits = "workerResourceLimits";
-  [@bs.get] external stderr: t('a) => Stream.t('a, Stream.readable) = "stderr";
-  [@bs.get] external stdin: t('a) => Stream.t('a, Stream.writable) = "stdin";
-  [@bs.get] external stdout: t('a) => Stream.t('a, Stream.readable) = "stdout";
+  [@bs.get] external stderr: t('a) => Stream.subtype('a, Stream.readable) = "stderr";
+  [@bs.get] external stdin: t('a) => Stream.subtype('a, Stream.writable) = "stdin";
+  [@bs.get] external stdout: t('a) => Stream.subtype('a, Stream.readable) = "stdout";
   [@bs.send] external terminate: t('a) => Js.Promise.t(int) = "terminate";
   [@bs.get] external threadId: t('a) => int = "threadId";
   [@bs.send] external unref: t('a) => unit = "unref";
@@ -122,9 +121,9 @@ module Worker = {
     [@bs.send] external postMessage: (t, T.message) => unit = "postMessage";
     [@bs.send] external ref: t => unit = "ref";
     [@bs.send] external resourceLimits: t => workerResourceLimits = "workerResourceLimits";
-    [@bs.get] external stderr: t => Stream.t('a, Stream.readable) = "stderr";
-    [@bs.get] external stdin: t => Stream.t('a, Stream.writable) = "stdin";
-    [@bs.get] external stdout: t => Stream.t('a, Stream.readable) = "stdout";
+    [@bs.get] external stderr: t => Stream.subtype('a, Stream.readable) = "stderr";
+    [@bs.get] external stdin: t => Stream.subtype('a, Stream.writable) = "stdin";
+    [@bs.get] external stdout: t => Stream.subtype('a, Stream.readable) = "stdout";
     [@bs.send] external terminate: t => Js.Promise.t(int) = "terminate";
     [@bs.get] external threadId: t => int = "threadId";
     [@bs.send] external unref: t => unit = "unref";


### PR DESCRIPTION
This branch got a little bit out of scope, but here are the main things:

- make all event handler types uncurried.
- implement the `off`, `once`, and `removeAllListeners` functions for subclasses of `EventEmitter`.
- fixes to some of the `Stream` subtypes.
- minor changes to `Stream` subtype polyvariant types.
- minor fixes in random places.
- in the `FS` module, all functions that read/write string types are removed, along with the `encoding` parameters that coerce the function types.