### PR TITLE
Use bs.get for FileHandle.fd

### DIFF
--- a/src/Fs.re
+++ b/src/Fs.re
@@ -190,7 +190,7 @@ module FileHandle = {
   [@bs.send] external chown: (t, int, int) => Js.Promise.t(unit) = "chown";
   [@bs.send] external close: t => Js.Promise.t(unit) = "close";
   [@bs.send] external datasync: t => Js.Promise.t(unit) = "datasync";
-  [@bs.send] external fd: t => fd = "fd";
+  [@bs.get] external fd: t => fd = "fd";
 
   type readInfo = {
     bytesRead: int,


### PR DESCRIPTION
For me it isn't a function: https://nodejs.org/api/fs.html#fs_filehandle_fd and bs.send is for function then call a int. Maybe their are other just found it while searching for fd type.