### PR TITLE
Fix Process.cwd

### DIFF
--- a/__tests__/Process_test.re
+++ b/__tests__/Process_test.re
@@ -1,0 +1,10 @@
+open Jest;
+
+describe("Process", () => {
+  test("cwd should be of type 'string'", () => {
+    ExpectJs.(
+      expect(Process.cwd(Process.process, ())->Js.typeof)
+      |> toEqual("string")
+    )
+  })
+});

--- a/examples/StreamTextToFile.re
+++ b/examples/StreamTextToFile.re
@@ -3,7 +3,7 @@ let data = "Sample text to write to a file!" -> Buffer.fromString;
 let process = Process.process;
 
 let outputPath = Path.relative(
-  ~from= Process.cwd(process),
+  ~from= Process.cwd(process, ()),
   ~to_="example__output.txt"
 );
 

--- a/src/Process.re
+++ b/src/Process.re
@@ -173,7 +173,7 @@ include Events;
 [@bs.get] external argv: t => array(string) = "argv";
 [@bs.get] external argv0: t => string = "argv0";
 [@bs.send] external chdir: (t, string) => unit = "chdir";
-[@bs.send] external cwd: t => string = "cwd";
+[@bs.send] external cwd: (t, unit) => string = "cwd";
 [@bs.send] external disconnect: t => unit = "disconnect";
 [@bs.get] external env: t => Js.Dict.t(string) = "env";
 [@bs.get] external execArgv: t => array(string) = "execArgv";


### PR DESCRIPTION
Fix `process.cwd` returning **function** instead of **string**.

![should be](https://i.imgur.com/VK5u1B0.png)

i also create the test.

thank you for the work you have done on
        this project .