### PR TITLE
Add EventEmitter module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ bsb
 *.bs.js
 package-lock.json
 
-src/ScratchRE.re
-src/ScratchML.ml
+src/ScratchRe.re
+src/ScratchMl.ml

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,5 @@ bsb
 *.bs.js
 package-lock.json
 
-src/ScratchPadJs.js
 src/ScratchRE.re
 src/ScratchML.ml
-src/Events.re

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
-    "test": "jest"
+    "test": "jest",
+    "clean-build": "bsb -clean-world && bsb -make-world",
+    "clean-start": "bsb -clean-world && bsb -make-world -w",
+    "clean-test": "bsb -clean-world && jest"
   },
   "keywords": [
     "BuckleScript"

--- a/src/Event.re
+++ b/src/Event.re
@@ -1,0 +1,45 @@
+/**
+ * The `Event` type represents the strings/symbols used in Node to
+ * identify event types for `EventEmitter` and its subclasses, including
+ * streams, sockets, and servers.
+ * 
+ * Given a type signature `Event.t('a => 'b, 'ty)`, the first type
+ * variable, `'a => 'b`, denotes the type signature of the event listener
+ * function, and `'ty` denotes the type of the associated `EventEmitter`.
+ * 
+ * These abstract `Event.t` types must be passed to `EventEmitter`
+ * functions to register event listeners or emit events. By encoding the
+ * listener function type in a type variable, we can ensure that each
+ * listener has the correct type. The type parameter for the emitter
+ * prevents two different emitters from using each other's events.
+ * 
+ * While this gives us some degree of type safety, it is still possible
+ * to introduce runtime errors with this API. In particular, two or more
+ * `Event.t` types can be defined from the same string/symbol, but with
+ * different listener types. Therefore, we strongly recommend using
+ * 100% unique strings/symbols to define events.
+ * 
+ */
+type t('listener, 'ty);
+external fromString: string => t('a => 'b, 'ty) = "%identity";
+external fromSymbol: Js.Types.symbol => t('a => 'b, 'ty) = "%identity";
+external unsafeToString: t('a => 'b, 'ty) => string = "%identity";
+external unsafeToSymbol: t('a => 'b, 'ty) => Js.Types.symbol = "%identity";
+type case =
+  | String(string)
+  | Symbol(Js.Types.symbol)
+  | Unknown;
+let classify = evt => {
+  switch (Js.typeof(evt)) {
+  | "string" => String(unsafeToString(evt))
+  | "symbol" => Symbol(unsafeToSymbol(evt))
+  | _ => Unknown
+  };
+};
+let eq = (event1, event2) => {
+  switch (Js.typeof(event1), Js.typeof(event2)) {
+  | ("string", "string") => Obj.magic(event1) === Obj.magic(event2)
+  | ("symbol", "symbol") => Obj.magic(event1) === Obj.magic(event2)
+  | _ => false
+  };
+};

--- a/src/EventEmitter.re
+++ b/src/EventEmitter.re
@@ -1,0 +1,72 @@
+/**
+ * `Impl` is a functor which generates FFI bindings to Node's `EventEmitter`
+ * class for any type `t`. This is not inherently type-safe. Type-safety can
+ * be achieved by implementing the known `Event.t('a => 'b, t)` types
+ */
+module Impl = (T: {type t;}) => {
+  [@bs.send]
+  external addListener: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t =
+    "addListener";
+  [@bs.send]
+  external emit: (T.t, Event.t('a => 'b, T.t), 'a) => bool = "emit";
+  [@bs.get] external errorMonitor: T.t => Js.Types.symbol = "errorMonitor";
+  [@bs.send]
+  external eventNames:
+    (T.t, Event.t('a => 'b, T.t)) => array(Event.t('a => 'b, T.t)) =
+    "eventNames";
+  [@bs.send] external getMaxListeners: T.t => int = "getMaxListeners";
+  [@bs.send]
+  external listenerCount: (T.t, Event.t('a => 'b, T.t)) => int =
+    "listenerCount";
+  [@bs.send]
+  external listeners: (T.t, Event.t('a => 'b, T.t)) => array('a => 'b) =
+    "listeners";
+  [@bs.send]
+  external on: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t = "on";
+  [@bs.send]
+  external once: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t = "once";
+  [@bs.send]
+  external off: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t = "off";
+  [@bs.send]
+  external prependListener: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t =
+    "prependListener";
+  [@bs.send]
+  external prependOnceListener: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t =
+    "prependOnceListener";
+  [@bs.send] external removeAllListeners: T.t => T.t = "removeAllListeners";
+  [@bs.send]
+  external removeListener: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t =
+    "removeListener";
+  [@bs.send] external setMaxListeners: (T.t, int) => T.t = "setMaxListeners";
+
+  [@bs.send]
+  external onNewListener:
+    (
+      T.t,
+      [@bs.as "newListener"] _,
+      (Event.t('a => 'b, T.t), 'a => 'b) => unit
+    ) =>
+    T.t =
+    "on";
+  [@bs.send]
+  external onRemoveListener:
+    (
+      T.t,
+      [@bs.as "removeListener"] _,
+      (Event.t('a => 'b, T.t), 'a => 'b) => unit
+    ) =>
+    T.t =
+    "on";
+};
+
+/**
+ * A generative functor that creates a unique type `t` with the `EventEmitter`
+ * interface bindings.
+*/
+module Make = (()) => {
+  type t;
+  include Impl({
+    type nonrec t = t;
+  });
+  [@bs.module "events"] [@bs.new] external make: unit => t = "EventEmitter";
+};

--- a/src/EventEmitter.re
+++ b/src/EventEmitter.re
@@ -4,39 +4,133 @@
  * be achieved by implementing the known `Event.t('a => 'b, t)` types
  */
 module Impl = (T: {type t;}) => {
+  /**
+   * `addListener(emitter, event, listener)`
+   * 
+   * Adds a new event listener function to the event emitter.
+   */
   [@bs.send]
   external addListener: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t =
     "addListener";
+
   [@bs.send]
   external emit: (T.t, Event.t('a => 'b, T.t), 'a) => bool = "emit";
+
   [@bs.get] external errorMonitor: T.t => Js.Types.symbol = "errorMonitor";
+
   [@bs.send]
   external eventNames:
     (T.t, Event.t('a => 'b, T.t)) => array(Event.t('a => 'b, T.t)) =
     "eventNames";
+
   [@bs.send] external getMaxListeners: T.t => int = "getMaxListeners";
+
   [@bs.send]
   external listenerCount: (T.t, Event.t('a => 'b, T.t)) => int =
     "listenerCount";
   [@bs.send]
+
   external listeners: (T.t, Event.t('a => 'b, T.t)) => array('a => 'b) =
     "listeners";
+
+  /**
+   * `on(emitter, event, listener)`
+   * 
+   * Adds a new event listener function to the event emitter.
+   * Alias for `addListener`.
+   */
   [@bs.send]
   external on: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t = "on";
+
+  /**
+   * `once(emitter, event, listener)`
+   * 
+   * Adds a new **single-use** event listener function to the event
+   * emitter. Then next time the given event is emitted, this listener
+   * will fire exactly once, and then be removed from the emitter's
+   * internal listener array.
+   */
   [@bs.send]
   external once: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t = "once";
+
+  /**
+   * `off(emitter, event, listener)`
+   * 
+   * Removes the listener function from the event emitter.
+   * 
+   * The specified listener function is compared by **referential
+   * equality** to each function in the emitter's internal listener
+   * array.
+   * 
+   * This means that, when the target listener is initially added, that
+   * exact function reference must be maintained and provided here
+   * in order to ensure removal.
+   * 
+   * Alias for `removeListener`.
+   */
   [@bs.send]
   external off: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t = "off";
+  
+  /**
+   * `prependListener(emitter, event, listener)`
+   * 
+   * Adds a new event listener function to the event emitter.
+   * 
+   * Unlike `on` and `addListener`, `prependListener` adds the listener
+   * function to the front of the internal listener array, ensuring
+   * that this function is called before the rest of the listeners for
+   * the given event.
+   */
   [@bs.send]
   external prependListener: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t =
     "prependListener";
+
+  /**
+   * `prependListenerOnce(emitter, event, listener)`
+   * 
+   * Adds a new **single-use** event listener function to the event
+   * emitter. Then next time the given event is emitted, this listener
+   * will fire exactly once, and then be removed from the emitter's
+   * internal listener array.
+   * 
+   * Unlike `once`, `prependListenerOnce` adds the listener function
+   * to the front of the internal listener array, ensuring that this
+   * function is called before the rest of the listeners for the
+   * given event.
+   */
   [@bs.send]
   external prependOnceListener: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t =
     "prependOnceListener";
+
   [@bs.send] external removeAllListeners: T.t => T.t = "removeAllListeners";
+
+  /**
+   * `removeListener(emitter, event, listener)`
+   * 
+   * Removes the listener function from the event emitter.
+   * 
+   * The specified listener function is compared by **referential
+   * equality** to each function in the emitter's internal listener
+   * array.
+   * 
+   * This means that, when the target listener is initially added, that
+   * exact function reference must be maintained and provided here
+   * in order to ensure removal.
+   */
   [@bs.send]
   external removeListener: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t =
     "removeListener";
+
+  /**
+   * `setMaxListeners(emitter, numberOfListeners)`
+   * 
+   * Sets the maximum number of event listeners that may be added to
+   * an event emitter before Node begins emitting warnings.
+   * 
+   * By default, each event emitter has this value set to 10. This is
+   * intended to warn the user about possible memory leaks.
+   * `setMaxListeners` will increase this threshold.
+   */
   [@bs.send] external setMaxListeners: (T.t, int) => T.t = "setMaxListeners";
 
   [@bs.send]
@@ -48,6 +142,7 @@ module Impl = (T: {type t;}) => {
     ) =>
     T.t =
     "on";
+
   [@bs.send]
   external onRemoveListener:
     (

--- a/src/EventEmitter.re
+++ b/src/EventEmitter.re
@@ -6,7 +6,7 @@
 module Impl = (T: {type t;}) => {
   /**
    * `addListener(emitter, event, listener)`
-   * 
+   *
    * Adds a new event listener function to the event emitter.
    */
   [@bs.send]
@@ -29,13 +29,12 @@ module Impl = (T: {type t;}) => {
   external listenerCount: (T.t, Event.t('a => 'b, T.t)) => int =
     "listenerCount";
   [@bs.send]
-
   external listeners: (T.t, Event.t('a => 'b, T.t)) => array('a => 'b) =
     "listeners";
 
   /**
    * `on(emitter, event, listener)`
-   * 
+   *
    * Adds a new event listener function to the event emitter.
    * Alias for `addListener`.
    */
@@ -44,7 +43,7 @@ module Impl = (T: {type t;}) => {
 
   /**
    * `once(emitter, event, listener)`
-   * 
+   *
    * Adds a new **single-use** event listener function to the event
    * emitter. Then next time the given event is emitted, this listener
    * will fire exactly once, and then be removed from the emitter's
@@ -55,27 +54,27 @@ module Impl = (T: {type t;}) => {
 
   /**
    * `off(emitter, event, listener)`
-   * 
+   *
    * Removes the listener function from the event emitter.
-   * 
+   *
    * The specified listener function is compared by **referential
    * equality** to each function in the emitter's internal listener
    * array.
-   * 
+   *
    * This means that, when the target listener is initially added, that
    * exact function reference must be maintained and provided here
    * in order to ensure removal.
-   * 
+   *
    * Alias for `removeListener`.
    */
   [@bs.send]
   external off: (T.t, Event.t('a => 'b, T.t), 'a => 'b) => T.t = "off";
-  
+
   /**
    * `prependListener(emitter, event, listener)`
-   * 
+   *
    * Adds a new event listener function to the event emitter.
-   * 
+   *
    * Unlike `on` and `addListener`, `prependListener` adds the listener
    * function to the front of the internal listener array, ensuring
    * that this function is called before the rest of the listeners for
@@ -87,12 +86,12 @@ module Impl = (T: {type t;}) => {
 
   /**
    * `prependListenerOnce(emitter, event, listener)`
-   * 
+   *
    * Adds a new **single-use** event listener function to the event
    * emitter. Then next time the given event is emitted, this listener
    * will fire exactly once, and then be removed from the emitter's
    * internal listener array.
-   * 
+   *
    * Unlike `once`, `prependListenerOnce` adds the listener function
    * to the front of the internal listener array, ensuring that this
    * function is called before the rest of the listeners for the
@@ -106,13 +105,13 @@ module Impl = (T: {type t;}) => {
 
   /**
    * `removeListener(emitter, event, listener)`
-   * 
+   *
    * Removes the listener function from the event emitter.
-   * 
+   *
    * The specified listener function is compared by **referential
    * equality** to each function in the emitter's internal listener
    * array.
-   * 
+   *
    * This means that, when the target listener is initially added, that
    * exact function reference must be maintained and provided here
    * in order to ensure removal.
@@ -123,35 +122,16 @@ module Impl = (T: {type t;}) => {
 
   /**
    * `setMaxListeners(emitter, numberOfListeners)`
-   * 
+   *
    * Sets the maximum number of event listeners that may be added to
    * an event emitter before Node begins emitting warnings.
-   * 
+   *
    * By default, each event emitter has this value set to 10. This is
    * intended to warn the user about possible memory leaks.
    * `setMaxListeners` will increase this threshold.
    */
-  [@bs.send] external setMaxListeners: (T.t, int) => T.t = "setMaxListeners";
-
   [@bs.send]
-  external onNewListener:
-    (
-      T.t,
-      [@bs.as "newListener"] _,
-      (Event.t('a => 'b, T.t), 'a => 'b) => unit
-    ) =>
-    T.t =
-    "on";
-
-  [@bs.send]
-  external onRemoveListener:
-    (
-      T.t,
-      [@bs.as "removeListener"] _,
-      (Event.t('a => 'b, T.t), 'a => 'b) => unit
-    ) =>
-    T.t =
-    "on";
+  external setMaxListeners: (T.t, int) => T.t = "setMaxListeners";
 };
 
 /**

--- a/test/__tests__/EventEmitter_test.re
+++ b/test/__tests__/EventEmitter_test.re
@@ -1,0 +1,122 @@
+open Jest;
+
+describe("EventEmitter", () => {
+  test(
+    "'Emitter.make' should create a new emitter instance that is defined", () => {
+    open! ExpectJs;
+    open! EventEmitterTestLib;
+    let emitter = Emitter1.make();
+    expect(emitter->Js.Undefined.return) |> toBeDefined;
+  });
+
+  test("'Emitter.addListener' should add a new event listener", () => {
+    open! ExpectJs;
+    open! EventEmitterTestLib;
+    let listeners =
+      Emitter1.(
+        {
+          make()->addListener(Events.text, _ => ())->listeners(Events.text);
+        }
+      );
+    expect(Array.length(listeners)) |> toBe(1);
+  });
+
+  test("'Emitter.on' should add a new event listener", () => {
+    open! ExpectJs;
+    open! EventEmitterTestLib;
+    let listeners =
+      Emitter1.(
+        {
+          make()->on(Events.text, _ => ())->listeners(Events.text);
+        }
+      );
+    expect(Array.length(listeners)) |> toBe(1);
+  });
+
+  test("'Emitter.on' should add a new event listener", () => {
+    open! ExpectJs;
+    open! EventEmitterTestLib;
+    let listeners =
+      Emitter1.(
+        {
+          make()->on(Events.text, _ => ())->listeners(Events.text);
+        }
+      );
+    expect(Array.length(listeners)) |> toBe(1);
+  });
+
+  test("'Emitter.removeListener' should remove the event listener", () => {
+    open! ExpectJs;
+    open! EventEmitterTestLib;
+    let eventListener = (_) => ();
+    let listeners =
+      Emitter1.(
+        {
+          make()
+            |> on(_, Events.text, eventListener)
+            |> removeListener(_, Events.text, eventListener)
+            |> listeners(_, Events.text);
+        }
+      );
+    expect(Array.length(listeners)) |> toBe(0);
+  });
+
+  test("'Emitter.off' should remove the event listener", () => {
+    open! ExpectJs;
+    open! EventEmitterTestLib;
+    let eventListener = (_) => ();
+    let listeners =
+      Emitter1.(
+        {
+          make()
+            |> on(_, Events.text, eventListener)
+            |> off(_, Events.text, eventListener)
+            |> listeners(_, Events.text);
+        }
+      );
+    expect(Array.length(listeners)) |> toBe(0);
+  });
+
+  test("'Emitter.emit' should execute each listener for the correct event", () => {
+    open! ExpectJs;
+    open! EventEmitterTestLib;
+    let ref1 = ref(0);
+    let ref2 = ref(0);
+    let data1 = 1;
+    let data2 = 2;
+    let listener1 = (_) => { ref1 := data1; };
+    let listener2 = (_) => { ref2 := data2; };
+    Emitter1.({
+        let emitter =
+          make()
+          |> on(_, Events.integer, listener1)
+          |> on(_, Events.integer, listener2);
+          emit(emitter, Events.integer, data1)->ignore;
+          emit(emitter, Events.integer, data2)->ignore;
+    });
+    Assert.strictEqual(ref1^, 1);
+    Assert.strictEqual(ref2^, 2);
+    expect(ref1^ === 1 && ref2^ === 2) |> toBe(true);
+  });
+
+  test("'Emitter.removeAllListeners' should remove all event listeners", () => {
+    open! ExpectJs;
+    open! EventEmitterTestLib;
+    let eventListener = (_) => ();
+    let emitter =
+      Emitter1.(
+        {
+          make()
+            |> on(_, Events.text, eventListener)
+            |> on(_, Events.text, eventListener)
+            |> on(_, Events.text, eventListener)
+        }
+      );
+    // Make sure 3 listeners were indeed added:
+    Assert.strictEqual(Emitter1.(listeners(emitter, Events.text))->Array.length, 3);
+    // Remove all the listeners:
+    Emitter1.removeAllListeners(emitter)->ignore;
+    expect(Emitter1.(listeners(emitter, Events.text))->Array.length) |> toBe(0);
+  });
+
+});

--- a/test/test_lib/EventEmitterTestLib.re
+++ b/test/test_lib/EventEmitterTestLib.re
@@ -1,0 +1,14 @@
+module Emitter1 = {
+  include EventEmitter.Make();
+
+  let uniqueSymbol: Js.Types.symbol = [%raw {|Symbol("emitter1")|}];
+
+  module Events = {
+    let symbol: Event.t(Js.Types.symbol => unit, t) = Event.fromSymbol(uniqueSymbol);
+    let text: Event.t(string => unit, t) = Event.fromString("text");
+    let integer: Event.t(int => unit, t) = Event.fromString("integer");
+    let textAndInteger: Event.t((string, int) => unit, t) = Event.fromString("textAndInteger");
+  };
+
+};
+


### PR DESCRIPTION
This PR provides a fairly straightforward implementation of the `EventEmitter` bindings. I tried very hard to come up with a implementation in which `Stream.t` is a subtype of `EventEmitter`, but there are a lot of complications with that.

The most important problem is establishing some degree of type safety with respect to emitters, listeners, and events.  Each emitter should only be allowed to register listeners for *its own* set of events (not just *any* `Event.t`). Each event should also have *exactly one* valid listener signature. Therefore we use the encoding `Event.t('listener, 'emitter)` to try to uphold those invariants.

I explain most of this stuff in a doc comment in the `Event` module.

Here's a working example of the API in use:
```reason
module MyEmitter = {
  include EventEmitter.Make({});
  module Events = {
    let greeting: Event.t(string => unit, t) = Event.fromString("greeting");
    let insult: Event.t(string => unit, t) = Event.fromString("insult");
  };
};

module Test = {
  let emitter = MyEmitter.make();
  let result = {
    open MyEmitter;

    emitter
    ->on(Events.greeting, Js.log)
    ->on(Events.insult, Js.log)
    ->emit(Events.greeting, "Hello")
    ->ignore;

    emitter->listenerCount(Events.greeting);
  };
  Js.log(result);
};
```
As you can see, because the `Event.fromString` & `Event.fromSymbol` functions have polymorphic return values, each event must have an explicitly annotated type. This is how you define event listener signatures.

It's still possible to shoot yourself in the foot by using the same string or symbol to create multiple events with different listener function types, but I think it's acceptable. We can just warn about it in the docs.

Let me know what you think!