### PR TITLE
Fix readFile bindings

### DIFF
--- a/src/Fs.re
+++ b/src/Fs.re
@@ -229,8 +229,8 @@ module FileHandle = {
     "read";
   [@bs.send] external readFile: t => Js.Promise.t(Buffer.t) = "readFile";
   [@bs.send]
-  external readFileWith: (t, readFileOptions) => Js.Promise.t(Buffer.t) =
-    "read";
+  external readFileWith: (t, ~encoding: string) => Js.Promise.t(string) =
+    "readFile";
 
   [@bs.send] external stat: t => Js.Promise.t(Stats.t) = "stat";
   [@bs.send] external sync: t => Js.Promise.t(unit) = "sync";

--- a/src/Fs.re
+++ b/src/Fs.re
@@ -227,7 +227,7 @@ module FileHandle = {
     (t, Buffer.t, ~offset: int, ~length: int, ~position: int) =>
     Js.Promise.t(readInfo) =
     "read";
-  [@bs.send] external readFile: t => Js.Promise.t(Buffer.t) = "read";
+  [@bs.send] external readFile: t => Js.Promise.t(Buffer.t) = "readFile";
   [@bs.send]
   external readFileWith: (t, readFileOptions) => Js.Promise.t(Buffer.t) =
     "read";

--- a/test/__tests__/Fs_test.re
+++ b/test/__tests__/Fs_test.re
@@ -19,5 +19,22 @@ describe("Fs", () => {
            |> resolve
          );
        })
-  })
+  });
+  testPromise("readFileWith should read entire file as a string", () => {
+    open_(Global.filename, Flag.read)
+    |> then_(fh =>
+         Fs.FileHandle.readFileWith(fh, ~encoding="UTF-8")
+         |> then_(buffer =>
+              FileHandle.close(fh) |> then_(_ => resolve(buffer))
+            )
+       )
+    |> then_(content => {
+         let needle = "Random string: uCF6c5f3Arrq";
+         Expect.(
+           expect(Js.String.indexOf(needle, content))
+           |> toBeGreaterThan(0)
+           |> resolve
+         );
+       })
+  });
 });

--- a/test/__tests__/Fs_test.re
+++ b/test/__tests__/Fs_test.re
@@ -1,0 +1,23 @@
+open Fs;
+open Jest;
+open Js.Promise;
+
+describe("Fs", () => {
+  testPromise("readFile should read entire file", () => {
+    open_(Global.filename, Flag.read)
+    |> then_(fh =>
+         Fs.FileHandle.readFile(fh)
+         |> then_(buffer =>
+              FileHandle.close(fh) |> then_(_ => resolve(buffer))
+            )
+       )
+    |> then_(buffer => {
+         let needle = "Random string: Gh2e71pdHhPxU";
+         Expect.(
+           expect(buffer->Buffer.indexOfString(needle))
+           |> toBeGreaterThan(0)
+           |> resolve
+         );
+       })
+  })
+});


### PR DESCRIPTION
Neither `FileHandle.readFile` or `FileHandle.readFileWith` worked, as their definitions were incorrect.

Tests have been added to verify expected behaviour.