### PR TITLE
Fix createWriteStreamOptions return type

### DIFF
--- a/src/Fs.re
+++ b/src/Fs.re
@@ -509,7 +509,7 @@ external createWriteStreamOptions:
     ~fs: Js.t({..})=?,
     unit
   ) =>
-  createReadStreamOptions;
+  createWriteStreamOptions;
 [@bs.module "fs"]
 external createWriteStream: string => WriteStream.t = "createWriteStream";
 


### PR DESCRIPTION
Looks like there was a small typo here. Thanks for this library!